### PR TITLE
Add comprehensive tests for storage, help, and persistence

### DIFF
--- a/src/test/java/seedu/duke/HelpCommandTest.java
+++ b/src/test/java/seedu/duke/HelpCommandTest.java
@@ -1,7 +1,10 @@
 package seedu.duke;
 
 import org.junit.jupiter.api.Test;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HelpCommandTest {
 
@@ -11,8 +14,27 @@ public class HelpCommandTest {
         ExpenseList expenseList = new ExpenseList();
         HelpCommand helpCommand = new HelpCommand(ui);
 
-        // Since HelpCommand just triggers a UI print, we verify it doesn't crash the program
         assertDoesNotThrow(() -> helpCommand.execute(expenseList),
                 "HelpCommand should execute successfully without throwing errors");
+    }
+
+    @Test
+    public void execute_helpCommand_outputContainsAllCommands() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+
+        new HelpCommand(new Ui()).execute(new ExpenseList());
+
+        System.setOut(original);
+        String output = out.toString();
+
+        assertTrue(output.contains("add"), "Help output should list add command");
+        assertTrue(output.contains("list"), "Help output should list list command");
+        assertTrue(output.contains("delete"), "Help output should list delete command");
+        assertTrue(output.contains("edit"), "Help output should list edit command");
+        assertTrue(output.contains("budget"), "Help output should list budget command");
+        assertTrue(output.contains("total"), "Help output should list total command");
+        assertTrue(output.contains("exit"), "Help output should list exit command");
     }
 }

--- a/src/test/java/seedu/duke/SpendSwiftTest.java
+++ b/src/test/java/seedu/duke/SpendSwiftTest.java
@@ -44,6 +44,56 @@ class SpendSwiftTest {
         assertTrue(output.contains("Unknown command. Type 'help' to see available commands."));
     }
 
+    @Test
+    public void run_persistenceAcrossRestart_expensesReloadedOnNextRun() {
+        // First session: add an expense and exit (triggers save)
+        runWithInput("add 8.00 Sushi\nexit\n", tempDir);
+
+        // Second session: same data directory, expenses should be reloaded
+        String output = runWithInput("list\nexit\n", tempDir);
+
+        assertTrue(output.contains("Sushi"),
+                "Expenses added in a previous session should be reloaded from disk");
+        assertTrue(output.contains("$8.00"),
+                "Reloaded expense should retain its original amount");
+    }
+
+    @Test
+    public void run_deleteAfterAdd_listShowsRemainingExpenses() {
+        String output = runWithInput("add 5.00 Coffee\nadd 10.00 Lunch\ndelete 1\nlist\nexit\n", tempDir);
+
+        assertTrue(output.contains("I've removed this expense:"),
+                "Delete confirmation should be shown");
+        assertTrue(output.contains("Lunch"),
+                "Remaining expense should still appear in list");
+    }
+
+    @Test
+    public void run_blankLines_ignoredGracefully() {
+        String output = runWithInput("\n\n\nadd 3.00 Tea\n\nexit\n", tempDir);
+
+        assertTrue(output.contains("Tea"),
+                "Blank lines should be ignored and valid commands still processed");
+    }
+
+    @Test
+    public void run_deleteOutOfBoundsIndex_showsInvalidIndex() {
+        String output = runWithInput("add 5.00 Coffee\ndelete 999\nexit\n", tempDir);
+
+        assertTrue(output.contains("Invalid index"),
+                "Deleting an out-of-bounds index should show invalid index error");
+    }
+
+    @Test
+    public void run_addWithCategoryAndDate_expenseStoredCorrectly() {
+        String output = runWithInput("add 12.50 /c Food /da 2026-03-24 Chicken Rice\nlist\nexit\n", tempDir);
+
+        assertTrue(output.contains("Chicken Rice"),
+                "Expense description should appear in list output");
+        assertTrue(output.contains("Food"),
+                "Category should appear in list output");
+    }
+
     private String runWithInput(String input, Path workingDirectory) {
         InputStream originalIn = System.in;
         PrintStream originalOut = System.out;

--- a/src/test/java/seedu/duke/StorageTest.java
+++ b/src/test/java/seedu/duke/StorageTest.java
@@ -1,6 +1,7 @@
 package seedu.duke;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -86,5 +87,60 @@ public class StorageTest {
     public void save_nullExpenseList_throwsIllegalArgumentException() {
         Storage storage = new Storage(tempDir.resolve("expenses.txt").toString(), new Ui());
         assertThrows(IllegalArgumentException.class, () -> storage.save(null));
+    }
+
+    @Test
+    public void load_emptyFile_loadsNothingIntoList() throws IOException {
+        Path dataFilePath = tempDir.resolve("empty.txt");
+        Files.writeString(dataFilePath, "");
+        Storage storage = new Storage(dataFilePath.toString(), new Ui());
+        ExpenseList loadedList = new ExpenseList();
+        storage.load(loadedList);
+        assertEquals(0, loadedList.getSize(),
+                "Loading an empty file should result in an empty expense list");
+    }
+
+    @Test
+    public void load_v1FormatTwoFields_loadsExpenseWithDefaults() throws IOException {
+        Path dataFilePath = tempDir.resolve("v1-expenses.txt");
+        Files.writeString(dataFilePath, "5.50 | Coffee\n12.00 | Lunch\n");
+        Storage storage = new Storage(dataFilePath.toString(), new Ui());
+        ExpenseList loadedList = new ExpenseList();
+        storage.load(loadedList);
+        assertEquals(2, loadedList.getSize(),
+                "v1.0 two-field format should be parsed and loaded");
+        assertEquals("Coffee", loadedList.getExpense(0).getDescription());
+        assertEquals(5.50, loadedList.getExpense(0).getAmount(), 0.0001);
+        assertEquals("Lunch", loadedList.getExpense(1).getDescription());
+        assertEquals(12.00, loadedList.getExpense(1).getAmount(), 0.0001);
+    }
+
+    @Test
+    public void saveAndLoad_withBudgetSet_budgetPersistsAcrossReload() {
+        Path dataFilePath = tempDir.resolve("budget-expenses.txt");
+        Storage storage = new Storage(dataFilePath.toString(), new Ui());
+        ExpenseList originalList = new ExpenseList();
+        originalList.setBudget(100.00);
+        originalList.addExpense(new Expense("Coffee", 5.50, "Food", LocalDate.parse("2026-03-24")));
+        storage.save(originalList);
+
+        ExpenseList loadedList = new ExpenseList();
+        storage.load(loadedList);
+        assertEquals(1, loadedList.getSize(),
+                "Expense saved alongside budget should be reloaded");
+        assertEquals(100.00, loadedList.getBudget(), 0.0001,
+                "Budget should survive a save-load cycle");
+        assertTrue(loadedList.hasBudget(),
+                "hasBudget should return true after reload");
+    }
+
+    @Test
+    public void load_missingFile_loadsNothingAndDoesNotThrow() {
+        Path dataFilePath = tempDir.resolve("nonexistent.txt");
+        Storage storage = new Storage(dataFilePath.toString(), new Ui());
+        ExpenseList loadedList = new ExpenseList();
+        storage.load(loadedList);
+        assertEquals(0, loadedList.getSize(),
+                "Loading from a missing file should leave the list empty without throwing");
     }
 }


### PR DESCRIPTION
## Summary
- **StorageTest**: 4 new tests covering empty file load, v1.0 two-field backward compatibility, budget persistence across save/load cycle, and missing file handling
- **HelpCommandTest**: new output test asserting all commands (add, list, delete, edit, budget, total, exit) appear in the help menu output
- **SpendSwiftTest**: 4 new integration tests covering persistence across restart, delete after add, blank line handling, and out-of-bounds delete

## Test plan
- [ ] `./gradlew test` — all 86 tests pass
- [ ] `./gradlew check` — checkstyle clean