### PR TITLE
Add /c category filter to find command

### DIFF
--- a/src/main/java/seedu/duke/FindCommand.java
+++ b/src/main/java/seedu/duke/FindCommand.java
@@ -3,44 +3,73 @@ package seedu.duke;
 import java.util.ArrayList;
 
 /**
- * Handles the logic for finding expenses that match a keyword.
+ * Handles the logic for finding expenses that match a keyword and/or category filter.
  * Searches case-insensitively across the description and category of each expense.
+ * When a category filter is specified, only expenses in that category are shown.
  */
 public class FindCommand extends Command {
     private final String keyword;
+    private final String categoryFilter;
 
     /**
-     * Constructs a FindCommand with the given UI and search keyword.
+     * Constructs a FindCommand with the given UI, search keyword, and optional category filter.
+     *
+     * @param ui             The Ui object used to display results.
+     * @param keyword        The keyword to search for. May be empty if categoryFilter is set.
+     * @param categoryFilter The category to filter by, or null for no category filter.
+     */
+    public FindCommand(Ui ui, String keyword, String categoryFilter) {
+        super(ui);
+        this.keyword = keyword;
+        this.categoryFilter = categoryFilter;
+    }
+
+    /**
+     * Constructs a FindCommand with keyword search only (no category filter).
      *
      * @param ui      The Ui object used to display results.
      * @param keyword The keyword to search for.
      */
     public FindCommand(Ui ui, String keyword) {
-        super(ui);
-        this.keyword = keyword;
+        this(ui, keyword, null);
     }
 
     /**
-     * Executes the find command by scanning all expenses for a case-insensitive
-     * keyword match in the description or category, then displaying the results.
+     * Executes the find command by scanning all expenses for matches based on
+     * keyword and/or category filter, then displaying the results.
      *
      * @param expenseList The list of expenses to search through.
      */
     @Override
     public void execute(ExpenseList expenseList) {
-        String lowerKeyword = keyword.toLowerCase();
         ArrayList<Expense> matches = new ArrayList<>();
 
         for (int i = 0; i < expenseList.getSize(); i++) {
             Expense expense = expenseList.getExpense(i);
-            boolean descriptionMatches = expense.getDescription().toLowerCase().contains(lowerKeyword);
-            boolean categoryMatches = expense.getCategory().toLowerCase().contains(lowerKeyword);
-            if (descriptionMatches || categoryMatches) {
-                matches.add(expense);
+
+            if (categoryFilter != null) {
+                boolean categoryMatches = expense.getCategory().toLowerCase()
+                        .equals(categoryFilter.toLowerCase());
+                if (!categoryMatches) {
+                    continue;
+                }
             }
+
+            if (!keyword.isEmpty()) {
+                String lowerKeyword = keyword.toLowerCase();
+                boolean descriptionMatches = expense.getDescription().toLowerCase()
+                        .contains(lowerKeyword);
+                boolean categoryMatches = expense.getCategory().toLowerCase()
+                        .contains(lowerKeyword);
+                if (!descriptionMatches && !categoryMatches) {
+                    continue;
+                }
+            }
+
+            matches.add(expense);
         }
 
-        ui.showFindResults(matches, keyword);
+        ui.showFindResults(matches, keyword, categoryFilter);
     }
 
     /**

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -82,11 +82,7 @@ public class Parser {
             return parseEditCommand(arguments, ui);
 
         case "find":
-            if (arguments.isEmpty()) {
-                ui.showFindUsage();
-                return null;
-            }
-            return new FindCommand(ui, arguments);
+            return parseFindCommand(arguments, ui);
 
         case "budget":
             if (arguments.isEmpty()) {
@@ -498,6 +494,48 @@ public class Parser {
         return new RepayCommand(ui, index);
     }
 
+
+    /**
+     * Parses the argument string for the find command and returns a FindCommand.
+     * Supports optional /c flag for category filtering.
+     * Valid forms: find KEYWORD, find /c CATEGORY, find KEYWORD /c CATEGORY.
+     *
+     * @param arguments The portion of user input after the find keyword.
+     * @param ui        The Ui instance used to display error or usage messages.
+     * @return A fully constructed FindCommand, or null if the input is invalid.
+     */
+    private static Command parseFindCommand(String arguments, Ui ui) {
+        if (arguments.isEmpty()) {
+            ui.showFindUsage();
+            return null;
+        }
+
+        String keyword = arguments;
+        String categoryFilter = null;
+
+        if (keyword.contains("/c")) {
+            int flagIdx = keyword.indexOf("/c");
+            String after = keyword.substring(flagIdx + 2).trim();
+            int nextSlash = after.indexOf('/');
+            String value = (nextSlash >= 0) ? after.substring(0, nextSlash).trim() : after.trim();
+
+            if (value.isEmpty()) {
+                ui.showFindUsage();
+                return null;
+            }
+            categoryFilter = value;
+            String before = keyword.substring(0, flagIdx).trim();
+            String remaining = (nextSlash >= 0) ? after.substring(nextSlash).trim() : "";
+            keyword = (before + " " + remaining).trim();
+        }
+
+        if (keyword.isEmpty() && categoryFilter == null) {
+            ui.showFindUsage();
+            return null;
+        }
+
+        return new FindCommand(ui, keyword, categoryFilter);
+    }
 
     /**
      * Parses a date string strictly following the YYYY-MM-DD format.

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -77,7 +77,7 @@ public class Ui {
         System.out.println("  delete INDEX                              - Delete an expense by index");
         System.out.println("  edit INDEX [/a AMOUNT] [/de DESC]         - Edit an existing expense");
         System.out.println("             [/c CATEGORY] [/da DATE]");
-        System.out.println("  find KEYWORD                              - Find expenses by keyword");
+        System.out.println("  find KEYWORD [/c CATEGORY]                - Find expenses by keyword/category");
         System.out.println("  sort category|date                        - Sort expenses");
         System.out.println("  stats                                     - Spending breakdown by category");
         System.out.println("  lend AMOUNT BORROWER [/da DATE]           - Record money lent to someone");
@@ -339,28 +339,51 @@ public class Ui {
      */
     public void showFindUsage() {
         System.out.println(LINE);
-        System.out.println("Usage: find KEYWORD");
+        System.out.println("Usage: find KEYWORD [/c CATEGORY]");
+        System.out.println("  find lunch           - search by keyword");
+        System.out.println("  find /c Food         - list all in category");
+        System.out.println("  find lunch /c Food   - keyword within category");
         System.out.println(LINE);
     }
 
     /**
-     * Displays the list of expenses that match the search keyword.
+     * Displays the list of expenses that match the search keyword and/or category filter.
      *
-     * @param results The list of matching expenses.
-     * @param keyword The keyword that was searched.
+     * @param results        The list of matching expenses.
+     * @param keyword        The keyword that was searched (may be empty).
+     * @param categoryFilter The category filter applied, or null if none.
      */
-    public void showFindResults(java.util.ArrayList<Expense> results, String keyword) {
+    public void showFindResults(java.util.ArrayList<Expense> results,
+                                String keyword, String categoryFilter) {
         System.out.println(LINE);
+        String searchDescription = buildSearchDescription(keyword, categoryFilter);
         if (results.isEmpty()) {
-            System.out.println("No expenses found matching: " + keyword);
+            System.out.println("No expenses found matching: " + searchDescription);
             System.out.println(LINE);
             return;
         }
-        System.out.println("Here are the matching expenses for \"" + keyword + "\":");
+        System.out.println("Here are the matching expenses for " + searchDescription + ":");
         for (int i = 0; i < results.size(); i++) {
             System.out.println((i + 1) + ". " + results.get(i));
         }
         System.out.println(LINE);
+    }
+
+    /**
+     * Builds a human-readable description of the search criteria.
+     *
+     * @param keyword        The keyword searched for (may be empty).
+     * @param categoryFilter The category filter applied, or null if none.
+     * @return A formatted string describing the search.
+     */
+    private String buildSearchDescription(String keyword, String categoryFilter) {
+        if (!keyword.isEmpty() && categoryFilter != null) {
+            return "\"" + keyword + "\" in category [" + categoryFilter + "]";
+        }
+        if (categoryFilter != null) {
+            return "category [" + categoryFilter + "]";
+        }
+        return "\"" + keyword + "\"";
     }
     /**
      * Displays the expense list after it has been sorted.

--- a/src/test/java/seedu/duke/FindCommandTest.java
+++ b/src/test/java/seedu/duke/FindCommandTest.java
@@ -111,4 +111,76 @@ public class FindCommandTest {
         System.setOut(original);
         assertTrue(out.toString().contains("Bus ride"), "Output should contain expense whose category matched");
     }
+
+    @Test
+    public void execute_categoryFilter_onlyMatchingCategory() {
+        ExpenseList expenseList = buildList();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+        new FindCommand(new Ui(), "", "Food").execute(expenseList);
+        System.setOut(original);
+
+        String output = out.toString();
+        assertTrue(output.contains("Coffee"), "Output should contain Food expense Coffee");
+        assertTrue(output.contains("Chicken Rice"), "Output should contain Food expense Chicken Rice");
+        assertFalse(output.contains("Bus ride"), "Output should not contain Transport expense");
+        assertFalse(output.contains("Movie ticket"), "Output should not contain Entertainment expense");
+    }
+
+    @Test
+    public void execute_categoryFilterCaseInsensitive_matchesCategory() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+
+        ExpenseList expenseList = buildList();
+        new FindCommand(new Ui(), "", "food").execute(expenseList);
+
+        System.setOut(original);
+        assertTrue(out.toString().contains("Coffee"), "Case-insensitive category filter should match");
+    }
+
+    @Test
+    public void execute_categoryFilterNoMatch_showsNoResults() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+
+        ExpenseList expenseList = buildList();
+        new FindCommand(new Ui(), "", "Utilities").execute(expenseList);
+
+        System.setOut(original);
+        assertTrue(out.toString().contains("No expenses found"), "Non-existent category should show no results");
+    }
+
+    @Test
+    public void execute_keywordWithCategoryFilter_filtersOnBoth() {
+        ExpenseList expenseList = buildList();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+        new FindCommand(new Ui(), "coffee", "Food").execute(expenseList);
+        System.setOut(original);
+
+        String output = out.toString();
+        assertTrue(output.contains("Coffee"), "Should find Coffee in Food category");
+        assertFalse(output.contains("Chicken Rice"), "Chicken Rice doesn't match keyword coffee");
+    }
+
+    @Test
+    public void execute_keywordWithWrongCategory_showsNoResults() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+
+        ExpenseList expenseList = buildList();
+        new FindCommand(new Ui(), "coffee", "Transport").execute(expenseList);
+
+        System.setOut(original);
+        assertTrue(out.toString().contains("No expenses found"),
+                "Coffee exists but not in Transport category");
+    }
 }

--- a/src/test/java/seedu/duke/ParserTest.java
+++ b/src/test/java/seedu/duke/ParserTest.java
@@ -398,4 +398,21 @@ public class ParserTest {
     public void parse_repayCommandExtraTokens_returnsNull() {
         assertNull(Parser.parse("repay 1 extra", ui));
     }
+
+    @Test
+    public void parse_findCommandWithCategory_returnsFindCommand() {
+        Command command = Parser.parse("find /c Food", ui);
+        assertTrue(command instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandKeywordAndCategory_returnsFindCommand() {
+        Command command = Parser.parse("find coffee /c Food", ui);
+        assertTrue(command instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandEmptyCategoryValue_returnsNull() {
+        assertNull(Parser.parse("find /c", ui));
+    }
 }


### PR DESCRIPTION
## Summary
- Enhances `FindCommand` to support an optional `/c CATEGORY` flag for filtering expenses by category
- Supports three usage forms: `find KEYWORD`, `find /c CATEGORY`, `find KEYWORD /c CATEGORY`
- Adds `parseFindCommand` method to `Parser` for flag extraction
- Updates `Ui` with improved find usage message and category-aware result display

## Test plan
- [x] FindCommandTest: 6 new tests for category filter (exact match, case-insensitive, no match, combined keyword+category, wrong category)
- [x] ParserTest: 3 new tests for `/c` flag parsing (category only, keyword+category, empty category value)
- [x] Checkstyle passes
- [x] All existing tests still pass