### PR TITLE
Add date, amount filters and sort to find

### DIFF
--- a/src/main/java/seedu/duke/FindCommand.java
+++ b/src/main/java/seedu/duke/FindCommand.java
@@ -1,42 +1,60 @@
 package seedu.duke;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Comparator;
 
 /**
- * Handles the logic for finding expenses that match a keyword and/or category filter.
- * Searches case-insensitively across the description and category of each expense.
- * When a category filter is specified, only expenses in that category are shown.
+ * Handles the logic for finding expenses using keyword, category, date range,
+ * and amount range filters. Results can be sorted ascending or descending by amount.
  */
 public class FindCommand extends Command {
     private final String keyword;
     private final String categoryFilter;
+    private final LocalDate dateMin;
+    private final LocalDate dateMax;
+    private final Double amountMin;
+    private final Double amountMax;
+    private final String sortOrder;
 
     /**
-     * Constructs a FindCommand with the given UI, search keyword, and optional category filter.
+     * Constructs a FindCommand with all filter and sort options.
      *
      * @param ui             The Ui object used to display results.
-     * @param keyword        The keyword to search for. May be empty if categoryFilter is set.
+     * @param keyword        The keyword to search for. May be empty if other filters are set.
      * @param categoryFilter The category to filter by, or null for no category filter.
+     * @param dateMin        Minimum date (inclusive), or null for no lower bound.
+     * @param dateMax        Maximum date (inclusive), or null for no upper bound.
+     * @param amountMin      Minimum amount (inclusive), or null for no lower bound.
+     * @param amountMax      Maximum amount (inclusive), or null for no upper bound.
+     * @param sortOrder      "asc" or "desc" to sort by amount, or null for default order.
      */
-    public FindCommand(Ui ui, String keyword, String categoryFilter) {
+    public FindCommand(Ui ui, String keyword, String categoryFilter,
+                       LocalDate dateMin, LocalDate dateMax,
+                       Double amountMin, Double amountMax, String sortOrder) {
         super(ui);
         this.keyword = keyword;
         this.categoryFilter = categoryFilter;
+        this.dateMin = dateMin;
+        this.dateMax = dateMax;
+        this.amountMin = amountMin;
+        this.amountMax = amountMax;
+        this.sortOrder = sortOrder;
     }
 
     /**
-     * Constructs a FindCommand with keyword search only (no category filter).
+     * Constructs a FindCommand with keyword search only (no filters).
      *
      * @param ui      The Ui object used to display results.
      * @param keyword The keyword to search for.
      */
     public FindCommand(Ui ui, String keyword) {
-        this(ui, keyword, null);
+        this(ui, keyword, null, null, null, null, null, null);
     }
 
     /**
      * Executes the find command by scanning all expenses for matches based on
-     * keyword and/or category filter, then displaying the results.
+     * the configured filters, optionally sorting, then displaying the results.
      *
      * @param expenseList The list of expenses to search through.
      */
@@ -47,29 +65,74 @@ public class FindCommand extends Command {
         for (int i = 0; i < expenseList.getSize(); i++) {
             Expense expense = expenseList.getExpense(i);
 
-            if (categoryFilter != null) {
-                boolean categoryMatches = expense.getCategory().toLowerCase()
-                        .equals(categoryFilter.toLowerCase());
-                if (!categoryMatches) {
-                    continue;
-                }
+            if (!matchesCategory(expense)) {
+                continue;
             }
-
-            if (!keyword.isEmpty()) {
-                String lowerKeyword = keyword.toLowerCase();
-                boolean descriptionMatches = expense.getDescription().toLowerCase()
-                        .contains(lowerKeyword);
-                boolean categoryMatches = expense.getCategory().toLowerCase()
-                        .contains(lowerKeyword);
-                if (!descriptionMatches && !categoryMatches) {
-                    continue;
-                }
+            if (!matchesKeyword(expense)) {
+                continue;
+            }
+            if (!matchesDateRange(expense)) {
+                continue;
+            }
+            if (!matchesAmountRange(expense)) {
+                continue;
             }
 
             matches.add(expense);
         }
 
+        if (sortOrder != null) {
+            sortMatches(matches);
+        }
+
         ui.showFindResults(matches, keyword, categoryFilter);
+    }
+
+    private boolean matchesCategory(Expense expense) {
+        if (categoryFilter == null) {
+            return true;
+        }
+        return expense.getCategory().toLowerCase().equals(categoryFilter.toLowerCase());
+    }
+
+    private boolean matchesKeyword(Expense expense) {
+        if (keyword.isEmpty()) {
+            return true;
+        }
+        String lowerKeyword = keyword.toLowerCase();
+        boolean descriptionMatches = expense.getDescription().toLowerCase().contains(lowerKeyword);
+        boolean categoryMatches = expense.getCategory().toLowerCase().contains(lowerKeyword);
+        return descriptionMatches || categoryMatches;
+    }
+
+    private boolean matchesDateRange(Expense expense) {
+        LocalDate date = expense.getDate();
+        if (dateMin != null && date.isBefore(dateMin)) {
+            return false;
+        }
+        if (dateMax != null && date.isAfter(dateMax)) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean matchesAmountRange(Expense expense) {
+        double amount = expense.getAmount();
+        if (amountMin != null && amount < amountMin) {
+            return false;
+        }
+        if (amountMax != null && amount > amountMax) {
+            return false;
+        }
+        return true;
+    }
+
+    private void sortMatches(ArrayList<Expense> matches) {
+        Comparator<Expense> comparator = Comparator.comparingDouble(Expense::getAmount);
+        if ("desc".equals(sortOrder)) {
+            comparator = comparator.reversed();
+        }
+        matches.sort(comparator);
     }
 
     /**

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -497,8 +497,8 @@ public class Parser {
 
     /**
      * Parses the argument string for the find command and returns a FindCommand.
-     * Supports optional /c flag for category filtering.
-     * Valid forms: find KEYWORD, find /c CATEGORY, find KEYWORD /c CATEGORY.
+     * Supports optional flags: /c CATEGORY, /dmin DATE, /dmax DATE,
+     * /amin AMOUNT, /amax AMOUNT, /sort asc|desc.
      *
      * @param arguments The portion of user input after the find keyword.
      * @param ui        The Ui instance used to display error or usage messages.
@@ -510,31 +510,113 @@ public class Parser {
             return null;
         }
 
-        String keyword = arguments;
+        String workingStr = arguments;
         String categoryFilter = null;
+        LocalDate dateMin = null;
+        LocalDate dateMax = null;
+        Double amountMin = null;
+        Double amountMax = null;
+        String sortOrder = null;
 
-        if (keyword.contains("/c")) {
-            int flagIdx = keyword.indexOf("/c");
-            String after = keyword.substring(flagIdx + 2).trim();
+        if (workingStr.contains("/sort")) {
+            int flagIdx = workingStr.indexOf("/sort");
+            String after = workingStr.substring(flagIdx + "/sort".length()).trim();
+            String[] tokens = after.split("\\s+", 2);
+            if (tokens[0].equals("asc") || tokens[0].equals("desc")) {
+                sortOrder = tokens[0];
+            } else {
+                ui.showFindUsage();
+                return null;
+            }
+            String before = workingStr.substring(0, flagIdx).trim();
+            String remaining = tokens.length > 1 ? tokens[1].trim() : "";
+            workingStr = (before + " " + remaining).trim();
+        }
+
+        if (workingStr.contains("/amin")) {
+            int flagIdx = workingStr.indexOf("/amin");
+            String after = workingStr.substring(flagIdx + "/amin".length()).trim();
+            String[] tokens = after.split("\\s+", 2);
+            try {
+                amountMin = Double.parseDouble(tokens[0]);
+            } catch (NumberFormatException e) {
+                ui.showInvalidAmount();
+                return null;
+            }
+            String before = workingStr.substring(0, flagIdx).trim();
+            String remaining = tokens.length > 1 ? tokens[1].trim() : "";
+            workingStr = (before + " " + remaining).trim();
+        }
+
+        if (workingStr.contains("/amax")) {
+            int flagIdx = workingStr.indexOf("/amax");
+            String after = workingStr.substring(flagIdx + "/amax".length()).trim();
+            String[] tokens = after.split("\\s+", 2);
+            try {
+                amountMax = Double.parseDouble(tokens[0]);
+            } catch (NumberFormatException e) {
+                ui.showInvalidAmount();
+                return null;
+            }
+            String before = workingStr.substring(0, flagIdx).trim();
+            String remaining = tokens.length > 1 ? tokens[1].trim() : "";
+            workingStr = (before + " " + remaining).trim();
+        }
+
+        if (workingStr.contains("/dmin")) {
+            int flagIdx = workingStr.indexOf("/dmin");
+            String after = workingStr.substring(flagIdx + "/dmin".length()).trim();
+            String[] tokens = after.split("\\s+", 2);
+            dateMin = parseDate(tokens[0], ui);
+            if (dateMin == null) {
+                return null;
+            }
+            String before = workingStr.substring(0, flagIdx).trim();
+            String remaining = tokens.length > 1 ? tokens[1].trim() : "";
+            workingStr = (before + " " + remaining).trim();
+        }
+
+        if (workingStr.contains("/dmax")) {
+            int flagIdx = workingStr.indexOf("/dmax");
+            String after = workingStr.substring(flagIdx + "/dmax".length()).trim();
+            String[] tokens = after.split("\\s+", 2);
+            dateMax = parseDate(tokens[0], ui);
+            if (dateMax == null) {
+                return null;
+            }
+            String before = workingStr.substring(0, flagIdx).trim();
+            String remaining = tokens.length > 1 ? tokens[1].trim() : "";
+            workingStr = (before + " " + remaining).trim();
+        }
+
+        if (workingStr.contains("/c")) {
+            int flagIdx = workingStr.indexOf("/c");
+            String after = workingStr.substring(flagIdx + 2).trim();
             int nextSlash = after.indexOf('/');
-            String value = (nextSlash >= 0) ? after.substring(0, nextSlash).trim() : after.trim();
-
+            String value = (nextSlash >= 0)
+                    ? after.substring(0, nextSlash).trim() : after.trim();
             if (value.isEmpty()) {
                 ui.showFindUsage();
                 return null;
             }
             categoryFilter = value;
-            String before = keyword.substring(0, flagIdx).trim();
+            String before = workingStr.substring(0, flagIdx).trim();
             String remaining = (nextSlash >= 0) ? after.substring(nextSlash).trim() : "";
-            keyword = (before + " " + remaining).trim();
+            workingStr = (before + " " + remaining).trim();
         }
 
-        if (keyword.isEmpty() && categoryFilter == null) {
+        String keyword = workingStr.trim();
+        boolean hasAnyFilter = categoryFilter != null || dateMin != null
+                || dateMax != null || amountMin != null || amountMax != null
+                || sortOrder != null;
+
+        if (keyword.isEmpty() && !hasAnyFilter) {
             ui.showFindUsage();
             return null;
         }
 
-        return new FindCommand(ui, keyword, categoryFilter);
+        return new FindCommand(ui, keyword, categoryFilter,
+                dateMin, dateMax, amountMin, amountMax, sortOrder);
     }
 
     /**

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -77,7 +77,8 @@ public class Ui {
         System.out.println("  delete INDEX                              - Delete an expense by index");
         System.out.println("  edit INDEX [/a AMOUNT] [/de DESC]         - Edit an existing expense");
         System.out.println("             [/c CATEGORY] [/da DATE]");
-        System.out.println("  find KEYWORD [/c CATEGORY]                - Find expenses by keyword/category");
+        System.out.println("  find KEYWORD [/c CAT] [/dmin DATE]        - Find/filter expenses");
+        System.out.println("       [/dmax DATE] [/amin AMT] [/amax AMT] [/sort asc|desc]");
         System.out.println("  sort category|date                        - Sort expenses");
         System.out.println("  stats                                     - Spending breakdown by category");
         System.out.println("  lend AMOUNT BORROWER [/da DATE]           - Record money lent to someone");
@@ -339,10 +340,13 @@ public class Ui {
      */
     public void showFindUsage() {
         System.out.println(LINE);
-        System.out.println("Usage: find KEYWORD [/c CATEGORY]");
-        System.out.println("  find lunch           - search by keyword");
-        System.out.println("  find /c Food         - list all in category");
-        System.out.println("  find lunch /c Food   - keyword within category");
+        System.out.println("Usage: find KEYWORD [/c CATEGORY] [/dmin DATE]"
+                + " [/dmax DATE] [/amin AMT] [/amax AMT] [/sort asc|desc]");
+        System.out.println("  find lunch                    - search by keyword");
+        System.out.println("  find /c Food                  - list all in category");
+        System.out.println("  find /dmin 2026-01-01          - from date onwards");
+        System.out.println("  find /amin 5 /amax 20          - amount between 5 and 20");
+        System.out.println("  find /c Food /sort desc        - Food expenses, highest first");
         System.out.println(LINE);
     }
 

--- a/src/test/java/seedu/duke/FindCommandTest.java
+++ b/src/test/java/seedu/duke/FindCommandTest.java
@@ -3,6 +3,7 @@ package seedu.duke;
 import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.time.LocalDate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,175 +13,260 @@ public class FindCommandTest {
     private ExpenseList buildList() {
         ExpenseList expenseList = new ExpenseList();
         Ui ui = new Ui();
-        new AddCommand(ui, "Coffee", 5.50, "Food", null).execute(expenseList);
-        new AddCommand(ui, "Bus ride", 1.20, "Transport", null).execute(expenseList);
-        new AddCommand(ui, "Chicken Rice", 4.00, "Food", null).execute(expenseList);
-        new AddCommand(ui, "Movie ticket", 12.00, "Entertainment", null).execute(expenseList);
+        new AddCommand(ui, "Coffee", 5.50, "Food",
+                LocalDate.of(2026, 1, 10)).execute(expenseList);
+        new AddCommand(ui, "Bus ride", 1.20, "Transport",
+                LocalDate.of(2026, 2, 15)).execute(expenseList);
+        new AddCommand(ui, "Chicken Rice", 4.00, "Food",
+                LocalDate.of(2026, 3, 1)).execute(expenseList);
+        new AddCommand(ui, "Movie ticket", 12.00, "Entertainment",
+                LocalDate.of(2026, 3, 20)).execute(expenseList);
         return expenseList;
     }
+
+    private FindCommand findWithCategory(Ui ui, String keyword, String category) {
+        return new FindCommand(ui, keyword, category, null, null, null, null, null);
+    }
+
+    // ===== Keyword tests =====
 
     @Test
     public void execute_matchingKeyword_doesNotChangeListSize() {
         ExpenseList expenseList = buildList();
-        Ui ui = new Ui();
-        FindCommand cmd = new FindCommand(ui, "coffee");
-        cmd.execute(expenseList);
+        new FindCommand(new Ui(), "coffee").execute(expenseList);
         assertEquals(4, expenseList.getSize());
     }
 
     @Test
     public void execute_caseInsensitiveMatch_findsExpense() {
         ExpenseList expenseList = buildList();
-        Ui ui = new Ui();
-        // "COFFEE" should match "Coffee" in description
-        FindCommand cmd = new FindCommand(ui, "COFFEE");
-        cmd.execute(expenseList);
-        assertEquals(4, expenseList.getSize()); // list is unchanged
+        new FindCommand(new Ui(), "COFFEE").execute(expenseList);
+        assertEquals(4, expenseList.getSize());
     }
 
     @Test
     public void execute_noMatch_listUnchanged() {
         ExpenseList expenseList = buildList();
-        Ui ui = new Ui();
-        FindCommand cmd = new FindCommand(ui, "sushi");
-        cmd.execute(expenseList);
-        assertEquals(4, expenseList.getSize());
-    }
-
-    @Test
-    public void execute_categoryKeyword_doesNotChangeListSize() {
-        ExpenseList expenseList = buildList();
-        Ui ui = new Ui();
-        // "Transport" is a category, not a description — should still match
-        FindCommand cmd = new FindCommand(ui, "transport");
-        cmd.execute(expenseList);
+        new FindCommand(new Ui(), "sushi").execute(expenseList);
         assertEquals(4, expenseList.getSize());
     }
 
     @Test
     public void execute_emptyList_executesWithoutException() {
         ExpenseList expenseList = new ExpenseList();
-        Ui ui = new Ui();
-        FindCommand cmd = new FindCommand(ui, "coffee");
-        cmd.execute(expenseList);
+        new FindCommand(new Ui(), "coffee").execute(expenseList);
         assertEquals(0, expenseList.getSize());
     }
 
     @Test
     public void shouldPersist_returnsFalse() {
-        Ui ui = new Ui();
-        FindCommand cmd = new FindCommand(ui, "coffee");
-        assertFalse(cmd.shouldPersist());
+        assertFalse(new FindCommand(new Ui(), "coffee").shouldPersist());
     }
 
     @Test
     public void execute_matchingKeyword_outputContainsDescription() {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PrintStream original = System.out;
-        System.setOut(new PrintStream(out));
-
         ExpenseList expenseList = buildList();
-        new FindCommand(new Ui(), "coffee").execute(expenseList);
-
-        System.setOut(original);
-        assertTrue(out.toString().contains("Coffee"), "Output should contain the matched expense description");
+        String output = captureOutput(() ->
+                new FindCommand(new Ui(), "coffee").execute(expenseList));
+        assertTrue(output.contains("Coffee"));
     }
 
     @Test
     public void execute_noMatch_outputContainsNoExpensesMessage() {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PrintStream original = System.out;
-        System.setOut(new PrintStream(out));
-
         ExpenseList expenseList = buildList();
-        new FindCommand(new Ui(), "sushi").execute(expenseList);
-
-        System.setOut(original);
-        assertTrue(out.toString().contains("No expenses found matching"), "Output should state no matches found");
+        String output = captureOutput(() ->
+                new FindCommand(new Ui(), "sushi").execute(expenseList));
+        assertTrue(output.contains("No expenses found matching"));
     }
 
     @Test
     public void execute_categoryKeyword_outputContainsMatchedExpense() {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PrintStream original = System.out;
-        System.setOut(new PrintStream(out));
-
         ExpenseList expenseList = buildList();
-        new FindCommand(new Ui(), "transport").execute(expenseList);
-
-        System.setOut(original);
-        assertTrue(out.toString().contains("Bus ride"), "Output should contain expense whose category matched");
+        String output = captureOutput(() ->
+                new FindCommand(new Ui(), "transport").execute(expenseList));
+        assertTrue(output.contains("Bus ride"));
     }
+
+    // ===== Category filter tests =====
 
     @Test
     public void execute_categoryFilter_onlyMatchingCategory() {
         ExpenseList expenseList = buildList();
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PrintStream original = System.out;
-        System.setOut(new PrintStream(out));
-        new FindCommand(new Ui(), "", "Food").execute(expenseList);
-        System.setOut(original);
-
-        String output = out.toString();
-        assertTrue(output.contains("Coffee"), "Output should contain Food expense Coffee");
-        assertTrue(output.contains("Chicken Rice"), "Output should contain Food expense Chicken Rice");
-        assertFalse(output.contains("Bus ride"), "Output should not contain Transport expense");
-        assertFalse(output.contains("Movie ticket"), "Output should not contain Entertainment expense");
+        String output = captureOutput(() ->
+                findWithCategory(new Ui(), "", "Food").execute(expenseList));
+        assertTrue(output.contains("Coffee"));
+        assertTrue(output.contains("Chicken Rice"));
+        assertFalse(output.contains("Bus ride"));
+        assertFalse(output.contains("Movie ticket"));
     }
 
     @Test
     public void execute_categoryFilterCaseInsensitive_matchesCategory() {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PrintStream original = System.out;
-        System.setOut(new PrintStream(out));
-
         ExpenseList expenseList = buildList();
-        new FindCommand(new Ui(), "", "food").execute(expenseList);
-
-        System.setOut(original);
-        assertTrue(out.toString().contains("Coffee"), "Case-insensitive category filter should match");
+        String output = captureOutput(() ->
+                findWithCategory(new Ui(), "", "food").execute(expenseList));
+        assertTrue(output.contains("Coffee"));
     }
 
     @Test
     public void execute_categoryFilterNoMatch_showsNoResults() {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PrintStream original = System.out;
-        System.setOut(new PrintStream(out));
-
         ExpenseList expenseList = buildList();
-        new FindCommand(new Ui(), "", "Utilities").execute(expenseList);
-
-        System.setOut(original);
-        assertTrue(out.toString().contains("No expenses found"), "Non-existent category should show no results");
+        String output = captureOutput(() ->
+                findWithCategory(new Ui(), "", "Utilities").execute(expenseList));
+        assertTrue(output.contains("No expenses found"));
     }
 
     @Test
     public void execute_keywordWithCategoryFilter_filtersOnBoth() {
         ExpenseList expenseList = buildList();
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PrintStream original = System.out;
-        System.setOut(new PrintStream(out));
-        new FindCommand(new Ui(), "coffee", "Food").execute(expenseList);
-        System.setOut(original);
-
-        String output = out.toString();
-        assertTrue(output.contains("Coffee"), "Should find Coffee in Food category");
-        assertFalse(output.contains("Chicken Rice"), "Chicken Rice doesn't match keyword coffee");
+        String output = captureOutput(() ->
+                findWithCategory(new Ui(), "coffee", "Food").execute(expenseList));
+        assertTrue(output.contains("Coffee"));
+        assertFalse(output.contains("Chicken Rice"));
     }
 
     @Test
     public void execute_keywordWithWrongCategory_showsNoResults() {
+        ExpenseList expenseList = buildList();
+        String output = captureOutput(() ->
+                findWithCategory(new Ui(), "coffee", "Transport").execute(expenseList));
+        assertTrue(output.contains("No expenses found"));
+    }
+
+    // ===== Date range filter tests =====
+
+    @Test
+    public void execute_dateMinFilter_excludesEarlierExpenses() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                LocalDate.of(2026, 3, 1), null, null, null, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("Chicken Rice"), "Expense on dmin date should be included");
+        assertTrue(output.contains("Movie ticket"), "Expense after dmin should be included");
+        assertFalse(output.contains("Coffee"), "Expense before dmin should be excluded");
+        assertFalse(output.contains("Bus ride"), "Expense before dmin should be excluded");
+    }
+
+    @Test
+    public void execute_dateMaxFilter_excludesLaterExpenses() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                null, LocalDate.of(2026, 2, 15), null, null, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("Coffee"), "Expense before dmax should be included");
+        assertTrue(output.contains("Bus ride"), "Expense on dmax date should be included");
+        assertFalse(output.contains("Chicken Rice"), "Expense after dmax should be excluded");
+    }
+
+    @Test
+    public void execute_dateRange_onlyExpensesInRange() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                LocalDate.of(2026, 2, 1), LocalDate.of(2026, 3, 10),
+                null, null, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("Bus ride"));
+        assertTrue(output.contains("Chicken Rice"));
+        assertFalse(output.contains("Coffee"));
+        assertFalse(output.contains("Movie ticket"));
+    }
+
+    // ===== Amount range filter tests =====
+
+    @Test
+    public void execute_amountMinFilter_excludesCheaperExpenses() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                null, null, 5.00, null, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("Coffee"), "$5.50 >= $5.00");
+        assertTrue(output.contains("Movie ticket"), "$12.00 >= $5.00");
+        assertFalse(output.contains("Bus ride"), "$1.20 < $5.00");
+        assertFalse(output.contains("Chicken Rice"), "$4.00 < $5.00");
+    }
+
+    @Test
+    public void execute_amountMaxFilter_excludesExpensiveExpenses() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                null, null, null, 5.00, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("Bus ride"), "$1.20 <= $5.00");
+        assertTrue(output.contains("Chicken Rice"), "$4.00 <= $5.00");
+        assertFalse(output.contains("Movie ticket"), "$12.00 > $5.00");
+    }
+
+    @Test
+    public void execute_amountRange_onlyExpensesInRange() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                null, null, 2.00, 6.00, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("Coffee"), "$5.50 in range");
+        assertTrue(output.contains("Chicken Rice"), "$4.00 in range");
+        assertFalse(output.contains("Bus ride"), "$1.20 below range");
+        assertFalse(output.contains("Movie ticket"), "$12.00 above range");
+    }
+
+    // ===== Sort order tests =====
+
+    @Test
+    public void execute_sortAsc_lowestAmountFirst() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                null, null, null, null, "asc");
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        int busPos = output.indexOf("Bus ride");
+        int coffeePos = output.indexOf("Coffee");
+        int moviePos = output.indexOf("Movie ticket");
+        assertTrue(busPos < coffeePos, "Bus ride ($1.20) should appear before Coffee ($5.50)");
+        assertTrue(coffeePos < moviePos, "Coffee ($5.50) should appear before Movie ($12.00)");
+    }
+
+    @Test
+    public void execute_sortDesc_highestAmountFirst() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                null, null, null, null, "desc");
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        int moviePos = output.indexOf("Movie ticket");
+        int coffeePos = output.indexOf("Coffee");
+        int busPos = output.indexOf("Bus ride");
+        assertTrue(moviePos < coffeePos, "Movie ($12.00) should appear before Coffee ($5.50)");
+        assertTrue(coffeePos < busPos, "Coffee ($5.50) should appear before Bus ride ($1.20)");
+    }
+
+    // ===== Combined filter tests =====
+
+    @Test
+    public void execute_categoryAndAmountRange_combinedFilter() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", "Food",
+                null, null, 5.00, null, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("Coffee"), "Coffee is Food and >= $5.00");
+        assertFalse(output.contains("Chicken Rice"), "Chicken Rice is Food but < $5.00");
+        assertFalse(output.contains("Bus ride"), "Bus ride is not Food");
+    }
+
+    @Test
+    public void execute_keywordAndDateRange_combinedFilter() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "chicken", null,
+                LocalDate.of(2026, 3, 1), null, null, null, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("Chicken Rice"));
+        assertFalse(output.contains("Coffee"), "Matches keyword but before dmin");
+    }
+
+    // ===== Helper =====
+
+    private String captureOutput(Runnable action) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PrintStream original = System.out;
         System.setOut(new PrintStream(out));
-
-        ExpenseList expenseList = buildList();
-        new FindCommand(new Ui(), "coffee", "Transport").execute(expenseList);
-
+        action.run();
         System.setOut(original);
-        assertTrue(out.toString().contains("No expenses found"),
-                "Coffee exists but not in Transport category");
+        return out.toString();
     }
 }

--- a/src/test/java/seedu/duke/ParserTest.java
+++ b/src/test/java/seedu/duke/ParserTest.java
@@ -415,4 +415,72 @@ public class ParserTest {
     public void parse_findCommandEmptyCategoryValue_returnsNull() {
         assertNull(Parser.parse("find /c", ui));
     }
+
+    @Test
+    public void parse_findCommandDateMin_returnsFindCommand() {
+        assertTrue(Parser.parse("find /dmin 2026-01-01", ui) instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandDateMax_returnsFindCommand() {
+        assertTrue(Parser.parse("find /dmax 2026-12-31", ui) instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandDateRange_returnsFindCommand() {
+        assertTrue(Parser.parse("find /dmin 2026-01-01 /dmax 2026-06-30", ui)
+                instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandInvalidDateMin_returnsNull() {
+        assertNull(Parser.parse("find /dmin baddate", ui));
+    }
+
+    @Test
+    public void parse_findCommandAmountMin_returnsFindCommand() {
+        assertTrue(Parser.parse("find /amin 5.00", ui) instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandAmountMax_returnsFindCommand() {
+        assertTrue(Parser.parse("find /amax 20.00", ui) instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandAmountRange_returnsFindCommand() {
+        assertTrue(Parser.parse("find /amin 5 /amax 20", ui) instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandInvalidAmountMin_returnsNull() {
+        assertNull(Parser.parse("find /amin abc", ui));
+    }
+
+    @Test
+    public void parse_findCommandInvalidAmountMax_returnsNull() {
+        assertNull(Parser.parse("find /amax xyz", ui));
+    }
+
+    @Test
+    public void parse_findCommandSortAsc_returnsFindCommand() {
+        assertTrue(Parser.parse("find /c Food /sort asc", ui) instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandSortDesc_returnsFindCommand() {
+        assertTrue(Parser.parse("find /c Food /sort desc", ui) instanceof FindCommand);
+    }
+
+    @Test
+    public void parse_findCommandSortInvalid_returnsNull() {
+        assertNull(Parser.parse("find /c Food /sort sideways", ui));
+    }
+
+    @Test
+    public void parse_findCommandAllFilters_returnsFindCommand() {
+        assertTrue(Parser.parse(
+                "find lunch /c Food /dmin 2026-01-01 /dmax 2026-12-31 /amin 1 /amax 50 /sort asc",
+                ui) instanceof FindCommand);
+    }
 }


### PR DESCRIPTION
## Summary
- Enhances `FindCommand` with comprehensive filtering: `/c CATEGORY`, `/dmin DATE`, `/dmax DATE`, `/amin AMOUNT`, `/amax AMOUNT`
- Adds `/sort asc|desc` flag to sort find results by amount
- Extracts matching logic into private helper methods (`matchesCategory`, `matchesKeyword`, `matchesDateRange`, `matchesAmountRange`)
- Updates `Parser.parseFindCommand()` to extract all new flags
- Updates `Ui` help text and find usage message

## Test plan
- [x] FindCommandTest: 22 tests covering keyword, category filter, date range, amount range, sort order, and combined filters
- [x] ParserTest: 14 new tests for all flag combinations and error cases (invalid dates, invalid amounts, invalid sort)
- [x] Checkstyle passes
- [x] All existing tests still pass