### PR TITLE
Improve branch coverage across commands

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -489,3 +489,11 @@ Given below are instructions to test the app manually.
 4. **Invalid budget input:**
    * Run: `budget 0`
    * *Expected:* An invalid budget message is shown and the current budget remains unchanged.
+
+### Automated Test Coverage
+
+The project uses JUnit 5 for automated testing. Test suites exist for every command class, the `Parser`, `Storage`, `ExpenseList`, `Expense`, `Loan`, and `Ui`. Integration tests in `SpendSwiftTest` verify end-to-end workflows including persistence across restarts.
+
+As of the latest build, the project achieves **97% line coverage** and **84% branch coverage** across all classes. The remaining uncovered branches are primarily:
+- **Assertion branches**: Java `assert` statements are counted as branches by JaCoCo. Since assertions verify invariants that are always true in correct code, these branches are intentionally never taken during normal execution.
+- **IOException catch blocks**: Error paths in `Storage` that fire only on filesystem failures (disk full, permission denied). These are platform-dependent and not practical to trigger in portable JUnit tests.

--- a/docs/team/TrijalSrimal.md
+++ b/docs/team/TrijalSrimal.md
@@ -32,9 +32,10 @@ This section summarizes my specific contributions to the project. My primary foc
     * Updated User Stories to cover find, filter, help, and persistence.
 
 * **Contributions to Team-based Tasks**:
-    * Drove test coverage from baseline to 89% line coverage / 79% branch coverage across the codebase.
+    * Drove test coverage from baseline to 97% line coverage / 84% branch coverage across the codebase.
     * Authored integration tests (`SpendSwiftTest`) verifying persistence across restarts, delete-after-add workflows, and edge cases.
     * Authored comprehensive test suites for `FindCommand`, `Storage`, `HelpCommand`, `ListCommand`, and `Parser`.
+    * Added tests for teammates' `AddCommand` (interactive category prompt via stdin) and `BudgetCommand` (view/set paths, budget exceeded warning) to improve overall project test coverage.
 
 * **Review/Mentoring Contributions**:
     * Reviewed and merged PRs from teammates, ensuring changes were compatible with the storage persistence flow.

--- a/src/test/java/seedu/duke/AddCommandTest.java
+++ b/src/test/java/seedu/duke/AddCommandTest.java
@@ -2,6 +2,7 @@ package seedu.duke;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 
@@ -105,5 +106,91 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(ui, "Coffee", 5.50, "Food", null);
 
         assertFalse(addCommand.isExit());
+    }
+
+    @Test
+    public void shouldPersist_returnsTrue() {
+        Ui ui = new Ui();
+        AddCommand addCommand = new AddCommand(ui, "Coffee", 5.50, "Food", null);
+        assertTrue(addCommand.shouldPersist());
+    }
+
+    @Test
+    public void execute_nullCategory_selectsFromPromptByNumber() {
+        // Simulate user typing "1" to select first category (Food)
+        java.io.InputStream originalIn = System.in;
+        System.setIn(new java.io.ByteArrayInputStream("1\n".getBytes()));
+
+        ExpenseList expenseList = new ExpenseList();
+        Ui ui = new Ui();
+        AddCommand cmd = new AddCommand(ui, "Coffee", 5.50, null, null);
+        cmd.execute(expenseList);
+
+        System.setIn(originalIn);
+        assertEquals(1, expenseList.getSize());
+        assertEquals("Food", expenseList.getExpense(0).getCategory());
+    }
+
+    @Test
+    public void execute_nullCategoryEmptyInput_defaultsToOthers() {
+        java.io.InputStream originalIn = System.in;
+        System.setIn(new java.io.ByteArrayInputStream("\n".getBytes()));
+
+        ExpenseList expenseList = new ExpenseList();
+        Ui ui = new Ui();
+        AddCommand cmd = new AddCommand(ui, "Coffee", 5.50, null, null);
+        cmd.execute(expenseList);
+
+        System.setIn(originalIn);
+        assertEquals(1, expenseList.getSize());
+        assertEquals("Others", expenseList.getExpense(0).getCategory());
+    }
+
+    @Test
+    public void execute_nullCategoryInvalidNumber_defaultsToOthers() {
+        java.io.InputStream originalIn = System.in;
+        System.setIn(new java.io.ByteArrayInputStream("999\n".getBytes()));
+
+        ExpenseList expenseList = new ExpenseList();
+        Ui ui = new Ui();
+        AddCommand cmd = new AddCommand(ui, "Coffee", 5.50, null, null);
+        cmd.execute(expenseList);
+
+        System.setIn(originalIn);
+        assertEquals(1, expenseList.getSize());
+        assertEquals("Others", expenseList.getExpense(0).getCategory());
+    }
+
+    @Test
+    public void execute_nullCategoryNewName_createsCategory() {
+        java.io.InputStream originalIn = System.in;
+        System.setIn(new java.io.ByteArrayInputStream("Snacks\n".getBytes()));
+
+        ExpenseList expenseList = new ExpenseList();
+        Ui ui = new Ui();
+        AddCommand cmd = new AddCommand(ui, "Chips", 3.00, null, null);
+        cmd.execute(expenseList);
+
+        System.setIn(originalIn);
+        assertEquals(1, expenseList.getSize());
+        assertEquals("Snacks", expenseList.getExpense(0).getCategory());
+        assertTrue(expenseList.getCategoryList().contains("Snacks"));
+    }
+
+    @Test
+    public void execute_overBudget_showsWarning() {
+        ExpenseList expenseList = new ExpenseList();
+        expenseList.setBudget(5.00);
+        Ui ui = new Ui();
+
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        java.io.PrintStream original = System.out;
+        System.setOut(new java.io.PrintStream(out));
+
+        new AddCommand(ui, "Dinner", 10.00, "Food", null).execute(expenseList);
+
+        System.setOut(original);
+        assertTrue(out.toString().contains("exceeded"),
+                "Adding over budget should show exceeded warning");
     }
 }

--- a/src/test/java/seedu/duke/BudgetCommandTest.java
+++ b/src/test/java/seedu/duke/BudgetCommandTest.java
@@ -82,4 +82,63 @@ public class BudgetCommandTest {
 
         assertFalse(command.isExit());
     }
+
+    @Test
+    public void shouldPersist_nullAmount_returnsFalse() {
+        Ui ui = new Ui();
+        BudgetCommand command = new BudgetCommand(ui, null);
+        assertFalse(command.shouldPersist(),
+                "Viewing budget should not trigger a save");
+    }
+
+    @Test
+    public void execute_viewBudgetWhenNotSet_showsNotSetMessage() {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        java.io.PrintStream original = System.out;
+        System.setOut(new java.io.PrintStream(out));
+
+        Ui ui = new Ui();
+        ExpenseList expenseList = new ExpenseList();
+        new BudgetCommand(ui, null).execute(expenseList);
+
+        System.setOut(original);
+        assertTrue(out.toString().contains("Budget not set"),
+                "Should show budget not set message");
+    }
+
+    @Test
+    public void execute_viewBudgetWhenSet_showsBudgetDetails() {
+        Ui ui = new Ui();
+        ExpenseList expenseList = new ExpenseList();
+        expenseList.setBudget(100.00);
+        expenseList.addExpense(new Expense("Lunch", 30.00, "Food", null));
+
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        java.io.PrintStream original = System.out;
+        System.setOut(new java.io.PrintStream(out));
+
+        new BudgetCommand(ui, null).execute(expenseList);
+
+        System.setOut(original);
+        String output = out.toString();
+        assertTrue(output.contains("100"), "Should show budget amount");
+        assertTrue(output.contains("30"), "Should show total spent");
+    }
+
+    @Test
+    public void execute_setBudgetOverSpending_showsWarning() {
+        Ui ui = new Ui();
+        ExpenseList expenseList = new ExpenseList();
+        expenseList.addExpense(new Expense("Laptop", 500.00, "Shopping", null));
+
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        java.io.PrintStream original = System.out;
+        System.setOut(new java.io.PrintStream(out));
+
+        new BudgetCommand(ui, 100.0).execute(expenseList);
+
+        System.setOut(original);
+        assertTrue(out.toString().contains("exceeded"),
+                "Setting budget below total should show warning");
+    }
 }

--- a/src/test/java/seedu/duke/RepayCommandTest.java
+++ b/src/test/java/seedu/duke/RepayCommandTest.java
@@ -83,4 +83,35 @@ public class RepayCommandTest {
     public void shouldPersist_returnsTrue() {
         assertTrue(new RepayCommand(ui, 1).shouldPersist());
     }
+
+    @Test
+    public void execute_noOutstandingLoans_showsNoLoansMessage() {
+        ExpenseList expenseList = new ExpenseList();
+
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        java.io.PrintStream original = System.out;
+        System.setOut(new java.io.PrintStream(out));
+
+        new RepayCommand(ui, 1).execute(expenseList);
+
+        System.setOut(original);
+        assertTrue(out.toString().contains("no outstanding loans"),
+                "Should show no outstanding loans message");
+    }
+
+    @Test
+    public void execute_indexOutOfRange_showsInvalidIndex() {
+        ExpenseList expenseList = new ExpenseList();
+        expenseList.addLoan(new Loan("Alice", 10.00, null));
+
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        java.io.PrintStream original = System.out;
+        System.setOut(new java.io.PrintStream(out));
+
+        new RepayCommand(ui, 99).execute(expenseList);
+
+        System.setOut(original);
+        assertTrue(out.toString().contains("Invalid loan index"),
+                "Out-of-range index should show error");
+    }
 }


### PR DESCRIPTION
## Summary
- **AddCommandTest**: 6 new tests covering interactive category prompt (stdin-based selection by number, empty input default, invalid number default, new category name creation), `shouldPersist()`, and budget exceeded warning
- **BudgetCommandTest**: 4 new tests covering view budget when not set, view budget when set, `shouldPersist()` for null amount, and budget exceeded on set
- **RepayCommandTest**: 2 new tests covering no outstanding loans and out-of-range index
- **DeveloperGuide**: Added automated test coverage section explaining 97% line / 84% branch coverage and why remaining branches are uncovered
- **PPP**: Updated test coverage stats and noted cross-team test contributions

Coverage improvements:
- AddCommand: 40% → 70% branches
- BudgetCommand: 57% → 85% branches
- Grand total: 95% → 97% lines, 83% → 84% branches

Closes #106 