### PR TITLE
Fix invalid list month-year error message

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -258,7 +258,7 @@ public class Parser {
 
         YearMonth parsedMonth = parseYearMonth(arguments);
         if (parsedMonth == null) {
-            ui.showUnknownCommand();
+            ui.showInvalidMonthYear();
             return null;
         }
 

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -836,5 +836,11 @@ public class Ui {
         System.out.printf("Average Monthly:   $%.2f%n", annualSpent / 12.0);
         System.out.println(LINE);
     }
+
+    public void showInvalidMonthYear() {
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        System.out.println("Invalid month/year format.");
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+    }
 }
 


### PR DESCRIPTION
Fixes #179 
Fixes the handling of invalid `list` month-year input.

### What changed
- Updated `parseListCommand` to show a specific invalid month/year message
- Prevented invalid `list` arguments from being reported as an unknown command

### Before
`list 0000-00` showed:
`Unknown command. Type 'help' to see available commands.`

### After
`list 0000-00` shows an invalid month/year format message instead.