### PR TITLE
Add partial repayment support and fix loan-related error messages

### DIFF
--- a/src/main/java/seedu/duke/command/RepayCommand.java
+++ b/src/main/java/seedu/duke/command/RepayCommand.java
@@ -7,28 +7,41 @@ import seedu.duke.ui.Ui;
 import java.util.ArrayList;
 
 /**
- * Handles the logic for marking a loan as repaid.
+ * Handles the logic for repaying a loan (fully or partially).
  */
 public class RepayCommand extends Command {
 
     private final int index;
+    private final Double amount;
 
     /**
-     * Constructs a RepayCommand for the given 1-based index.
+     * Constructs a RepayCommand for full repayment (backward compatible).
      *
      * @param ui    The Ui object used to display user-facing messages.
      * @param index The 1-based position in the outstanding loans list.
      */
     public RepayCommand(Ui ui, int index) {
+        this(ui, index, null);
+    }
+
+    /**
+     * Constructs a RepayCommand with an optional partial amount.
+     *
+     * @param ui     The Ui object used to display user-facing messages.
+     * @param index  The 1-based position in the outstanding loans list.
+     * @param amount The amount to repay, or null for full repayment.
+     */
+    public RepayCommand(Ui ui, int index, Double amount) {
         super(ui);
         assert ui != null : "Ui must not be null";
         assert index > 0 : "Index must be positive";
         this.index = index;
+        this.amount = amount;
     }
 
     /**
      * Executes the repay command.
-     * Finds the nth outstanding loan (1-based) and marks it as repaid.
+     * Finds the nth outstanding loan (1-based) and repays it fully or partially.
      * Displays an error if the index is out of range.
      * Displays an error if there are no outstanding loans at all.
      *
@@ -55,8 +68,22 @@ public class RepayCommand extends Command {
                 : "Loan index should be in range after validation";
 
         Loan loan = outstanding.get(zeroIndex);
-        loan.markRepaid();
-        ui.showRepaid(loan);
+
+        if (amount == null) {
+            loan.markRepaid();
+            ui.showRepaid(loan);
+        } else {
+            if (amount > loan.getOutstandingAmount() + 0.001) {
+                ui.showRepayExceedsOutstanding(loan.getOutstandingAmount());
+                return;
+            }
+            loan.repay(amount);
+            if (loan.isRepaid()) {
+                ui.showRepaid(loan);
+            } else {
+                ui.showPartialRepay(loan, amount);
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/duke/model/Loan.java
+++ b/src/main/java/seedu/duke/model/Loan.java
@@ -11,6 +11,7 @@ public class Loan extends Expense {
 
     private final String borrowerName;
     private boolean isRepaid;
+    private double amountRepaid;
 
     /**
      * Constructs a Loan with the given borrower, amount, and date.
@@ -27,6 +28,7 @@ public class Loan extends Expense {
         assert amount > 0 : "Loan amount must be positive";
         this.borrowerName = borrowerName.trim();
         this.isRepaid = false;
+        this.amountRepaid = 0;
     }
 
     /**
@@ -48,11 +50,66 @@ public class Loan extends Expense {
     }
 
     /**
-     * Marks this loan as repaid.
+     * Returns the total amount repaid so far.
+     *
+     * @return The cumulative repayment amount.
+     */
+    public double getAmountRepaid() {
+        return amountRepaid;
+    }
+
+    /**
+     * Returns the outstanding amount still owed.
+     *
+     * @return The remaining balance (original amount minus amount repaid).
+     */
+    public double getOutstandingAmount() {
+        return getAmount() - amountRepaid;
+    }
+
+    /**
+     * Marks this loan as fully repaid.
      * Can only move from outstanding → repaid (never reversed).
      */
     public void markRepaid() {
+        this.amountRepaid = getAmount();
         this.isRepaid = true;
+    }
+
+    /**
+     * Records a partial repayment. If the repayment covers the remaining
+     * outstanding amount, the loan is automatically marked as fully repaid.
+     *
+     * @param repayment The amount being repaid. Must be positive and
+     *                  not exceed the outstanding amount.
+     * @throws IllegalArgumentException if repayment is invalid.
+     */
+    public void repay(double repayment) {
+        if (repayment <= 0 || Double.isNaN(repayment) || Double.isInfinite(repayment)) {
+            throw new IllegalArgumentException("Repayment amount must be positive");
+        }
+        double outstanding = getOutstandingAmount();
+        if (repayment > outstanding + 0.001) {
+            throw new IllegalArgumentException("Repayment exceeds outstanding amount");
+        }
+        this.amountRepaid += repayment;
+        if (getOutstandingAmount() < 0.01) {
+            this.isRepaid = true;
+            this.amountRepaid = getAmount();
+        }
+    }
+
+    /**
+     * Sets the amount repaid directly (used when loading from storage).
+     *
+     * @param amountRepaid The cumulative amount already repaid.
+     */
+    public void setAmountRepaid(double amountRepaid) {
+        this.amountRepaid = amountRepaid;
+        if (getOutstandingAmount() < 0.01) {
+            this.isRepaid = true;
+            this.amountRepaid = getAmount();
+        }
     }
 
     /**
@@ -62,7 +119,15 @@ public class Loan extends Expense {
      */
     @Override
     public String toString() {
-        String status = isRepaid ? "[Repaid]" : "[Outstanding]";
+        String status;
+        if (isRepaid) {
+            status = "[Repaid]";
+        } else if (amountRepaid > 0) {
+            status = "[Outstanding: $" + String.format("%.2f", getOutstandingAmount())
+                    + " remaining]";
+        } else {
+            status = "[Outstanding]";
+        }
         return borrowerName
                 + " ($" + String.format("%.2f", getAmount()) + ")"
                 + " [Loan]"

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -472,7 +472,7 @@ public class Parser {
             return null;
         }
         if (amount == 0) {
-            ui.showZeroAmountWarning();
+            ui.showZeroLoanAmountWarning();
             return null;
         }
         if (amount < 0) {
@@ -534,7 +534,9 @@ public class Parser {
 
     /**
      * Parses the argument string for the repay command and returns a RepayCommand.
-     * Expects a single positive integer index with no trailing tokens.
+     * Supports:
+     *   repay INDEX          (full repayment)
+     *   repay INDEX AMOUNT   (partial repayment)
      *
      * @param arguments The portion of user input after the repay keyword.
      * @param ui        The Ui instance used to display error or usage messages.
@@ -547,7 +549,7 @@ public class Parser {
         }
 
         String[] tokens = arguments.split("\\s+");
-        if (tokens.length > 1) {
+        if (tokens.length > 2) {
             ui.showRepayUsage();
             return null;
         }
@@ -561,12 +563,26 @@ public class Parser {
         }
 
         if (index <= 0) {
-            ui.showInvalidIndex();
+            ui.showInvalidRepayIndex();
             return null;
         }
 
+        Double amount = null;
+        if (tokens.length == 2) {
+            try {
+                amount = Double.parseDouble(tokens[1]);
+            } catch (NumberFormatException e) {
+                ui.showInvalidAmount();
+                return null;
+            }
+            if (amount <= 0 || Double.isNaN(amount) || Double.isInfinite(amount)) {
+                ui.showInvalidAmount();
+                return null;
+            }
+        }
+
         assert index > 0 : "Repay index should be positive after validation";
-        return new RepayCommand(ui, index);
+        return new RepayCommand(ui, index, amount);
     }
 
 

--- a/src/main/java/seedu/duke/storage/Storage.java
+++ b/src/main/java/seedu/duke/storage/Storage.java
@@ -22,7 +22,7 @@ import java.util.TreeMap;
  * so that data persists between sessions.
  * Expense lines use the format: AMOUNT | DATE | CATEGORY | DESCRIPTION.
  * Budget lines use the format: BUDGET | YYYY-MM | AMOUNT.
- * Loan lines use the format: LOAN | AMOUNT | DATE | BORROWER | REPAID.
+ * Loan lines use the format: LOAN | AMOUNT | DATE | BORROWER | REPAID | AMOUNT_REPAID.
  */
 public class Storage {
     private static final String SEPARATOR = " | ";
@@ -34,11 +34,13 @@ public class Storage {
     private static final int IDX_CATEGORY    = 2;
     private static final int IDX_DESCRIPTION = 3;
     /** Number of fields expected on each saved loan line, excluding the LOAN prefix. */
-    private static final int LOAN_FIELD_COUNT  = 4;
+    private static final int LOAN_FIELD_COUNT  = 5;
+    private static final int LOAN_FIELD_COUNT_OLD = 4;
     private static final int LOAN_IDX_AMOUNT   = 0;
     private static final int LOAN_IDX_DATE     = 1;
     private static final int LOAN_IDX_BORROWER = 2;
     private static final int LOAN_IDX_REPAID   = 3;
+    private static final int LOAN_IDX_AMOUNT_REPAID = 4;
     private static final DateTimeFormatter DATE_FORMAT =
             DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT);
     private static final DateTimeFormatter YEAR_MONTH_FORMAT =
@@ -156,6 +158,7 @@ public class Storage {
                                 + SEPARATOR + loan.getDate()
                                 + SEPARATOR + loan.getBorrowerName()
                                 + SEPARATOR + loan.isRepaid()
+                                + SEPARATOR + loan.getAmountRepaid()
                                 + System.lineSeparator()
                 );
             }
@@ -220,7 +223,7 @@ public class Storage {
     private Loan parseLoanLine(String line) {
         String payload = line.substring(("LOAN" + SEPARATOR).length()).trim();
         String[] parts = payload.split(SPLIT_REGEX, LOAN_FIELD_COUNT);
-        if (parts.length != LOAN_FIELD_COUNT) {
+        if (parts.length != LOAN_FIELD_COUNT && parts.length != LOAN_FIELD_COUNT_OLD) {
             ui.showMalformedLineWarning(line);
             logger.warning("Malformed loan line (wrong field count): " + line);
             return null;
@@ -241,6 +244,10 @@ public class Storage {
                 return null;
             }
             Loan loan = new Loan(borrower, amount, date);
+            if (parts.length == LOAN_FIELD_COUNT) {
+                double amountRepaid = Double.parseDouble(parts[LOAN_IDX_AMOUNT_REPAID].trim());
+                loan.setAmountRepaid(amountRepaid);
+            }
             if (isRepaid) {
                 loan.markRepaid();
             }

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -137,7 +137,7 @@ public class Ui {
         System.out.println("  lend AMOUNT BORROWER [/da DATE]           - Record money lent to someone");
         System.out.println("  loans                                     - Show outstanding loans");
         System.out.println("  loans /all                                - Show all loans (incl. repaid)");
-        System.out.println("  repay INDEX                               - Mark a loan as repaid");
+        System.out.println("  repay INDEX [AMOUNT]                      - Repay a loan (fully or partially)");
         System.out.println("  help                                      - Show this help menu");
         System.out.println("  exit                                      - Exit the application");
         System.out.println("  forecast                                  - Show end-of-month spending forecast");
@@ -258,6 +258,16 @@ public class Ui {
     }
 
     /**
+     * Displays an error when the user attempts to lend $0.00.
+     */
+    public void showZeroLoanAmountWarning() {
+        System.out.println(LINE);
+        System.out.println("Oops! Loan amounts must be greater than $0.00.");
+        System.out.println("If you didn't spend any money, there is no need to track it!");
+        System.out.println(LINE);
+    }
+
+    /**
      * Displays an error when the date does not match YYYY-MM-DD or is not a real calendar date.
      */
     public void showInvalidDateFormat() {
@@ -282,6 +292,15 @@ public class Ui {
     public void showInvalidIndex() {
         System.out.println(LINE);
         System.out.println("Invalid index! Use 'list' to see valid numbers.");
+        System.out.println(LINE);
+    }
+
+    /**
+     * Displays an error when the repay index is invalid.
+     */
+    public void showInvalidRepayIndex() {
+        System.out.println(LINE);
+        System.out.println("Invalid index! Use 'loans' to see valid numbers.");
         System.out.println(LINE);
     }
 
@@ -648,7 +667,7 @@ public class Ui {
     }
 
     /**
-     * Displays confirmation after a loan is marked as repaid.
+     * Displays confirmation after a loan is marked as fully repaid.
      *
      * @param loan The loan that was marked repaid.
      */
@@ -656,6 +675,31 @@ public class Ui {
         System.out.println(LINE);
         System.out.println("Great! Marked as repaid:");
         System.out.println("  " + loan);
+        System.out.println(LINE);
+    }
+
+    /**
+     * Displays confirmation after a partial repayment is recorded.
+     *
+     * @param loan   The loan that was partially repaid.
+     * @param amount The amount that was repaid.
+     */
+    public void showPartialRepay(Loan loan, double amount) {
+        System.out.println(LINE);
+        System.out.println("Partial repayment of $" + String.format("%.2f", amount) + " recorded:");
+        System.out.println("  " + loan);
+        System.out.println(LINE);
+    }
+
+    /**
+     * Displays an error when the repay amount exceeds the outstanding balance.
+     *
+     * @param outstanding The current outstanding balance of the loan.
+     */
+    public void showRepayExceedsOutstanding(double outstanding) {
+        System.out.println(LINE);
+        System.out.println("Repayment amount exceeds the outstanding balance of $"
+                + String.format("%.2f", outstanding) + ".");
         System.out.println(LINE);
     }
 
@@ -707,7 +751,8 @@ public class Ui {
      */
     public void showRepayUsage() {
         System.out.println(LINE);
-        System.out.println("Usage: repay <index>");
+        System.out.println("Usage: repay <index>            (full repayment)");
+        System.out.println("       repay <index> <amount>   (partial repayment)");
         System.out.println("Use 'loans' to see the index of each outstanding loan.");
         System.out.println(LINE);
     }
@@ -763,13 +808,13 @@ public class Ui {
             if (monthlyBudget < 0) {
                 monthlyBudget = 0.0;
             }
-            
+
             double spent = expenseList.getTotalAmountForMonth(ym);
             double remaining = monthlyBudget - spent;
-            
+
             annualBudget += monthlyBudget;
             annualSpent += spent;
-            
+
             long usedPercent = 0;
             if (monthlyBudget > 0) {
                 usedPercent = Math.round((spent / monthlyBudget) * 100);
@@ -784,19 +829,19 @@ public class Ui {
                 barLength = 1;
             }
             String bar = "▒".repeat(barLength);
-            
+
             String monthName = java.time.Month.of(m).name();
             monthName = monthName.substring(0, 1).toUpperCase() + monthName.substring(1).toLowerCase();
             String usedStr = usedPercent + "%";
 
             System.out.printf("%-10s | $ %9.2f | $ %9.2f | $ %9.2f | %5s | %-20s %s%n",
-                              monthName, monthlyBudget, spent, remaining, usedStr, bar, usedStr);
+                    monthName, monthlyBudget, spent, remaining, usedStr, bar, usedStr);
         }
 
         System.out.println();
         System.out.println("=== PER CATEGORY BREAKDOWN ===");
         System.out.println();
-        
+
         java.util.Map<String, Double> categoryTotals = new java.util.LinkedHashMap<>();
         for (int i = 0; i < expenseList.getSize(); i++) {
             Expense e = expenseList.getExpense(i);
@@ -804,7 +849,7 @@ public class Ui {
                 categoryTotals.put(e.getCategory(), categoryTotals.getOrDefault(e.getCategory(), 0.0) + e.getAmount());
             }
         }
-        
+
         if (categoryTotals.isEmpty()) {
             System.out.println("No expenses for this year.");
         } else {
@@ -812,9 +857,9 @@ public class Ui {
             System.out.println("Category             | Spent        | Trend");
             System.out.println("---------------------+--------------+-------------------------");
             for (java.util.Map.Entry<String, Double> entry : categoryTotals.entrySet().stream()
-                .sorted((e1, e2) -> Double.compare(e2.getValue(), e1.getValue()))
-                .toList()) {
-                
+                    .sorted((e1, e2) -> Double.compare(e2.getValue(), e1.getValue()))
+                    .toList()) {
+
                 int bLen = 0;
                 if (maxCat > 0) {
                     bLen = (int) Math.round((entry.getValue() / maxCat) * 20);
@@ -843,4 +888,3 @@ public class Ui {
         System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
     }
 }
-

--- a/src/test/java/seedu/duke/command/RepayCommandTest.java
+++ b/src/test/java/seedu/duke/command/RepayCommandTest.java
@@ -118,4 +118,42 @@ public class RepayCommandTest {
         assertTrue(out.toString().contains("Invalid loan index"),
                 "Out-of-range index should show error");
     }
+
+    @Test
+    public void execute_partialRepay_reducesOutstandingAmount() {
+        new RepayCommand(ui, 1, 10.00).execute(expenseList);
+        Loan loan = expenseList.getLoan(0);
+        assertFalse(loan.isRepaid());
+        assertEquals(10.00, loan.getAmountRepaid(), 0.0001);
+        assertEquals(10.00, loan.getOutstandingAmount(), 0.0001);
+    }
+
+    @Test
+    public void execute_partialRepayFullAmount_marksAsRepaid() {
+        new RepayCommand(ui, 1, 20.00).execute(expenseList);
+        assertTrue(expenseList.getLoan(0).isRepaid());
+    }
+
+    @Test
+    public void execute_partialRepayExceedsOutstanding_doesNotModifyLoan() {
+        new RepayCommand(ui, 1, 999.00).execute(expenseList);
+        assertFalse(expenseList.getLoan(0).isRepaid());
+        assertEquals(0, expenseList.getLoan(0).getAmountRepaid(), 0.0001);
+    }
+
+    @Test
+    public void execute_multiplePartialRepays_accumulateCorrectly() {
+        new RepayCommand(ui, 1, 5.00).execute(expenseList);
+        new RepayCommand(ui, 1, 10.00).execute(expenseList);
+        Loan loan = expenseList.getLoan(0);
+        assertEquals(15.00, loan.getAmountRepaid(), 0.0001);
+        assertEquals(5.00, loan.getOutstandingAmount(), 0.0001);
+        assertFalse(loan.isRepaid());
+    }
+
+    @Test
+    public void execute_nullAmount_performsFullRepay() {
+        new RepayCommand(ui, 1, null).execute(expenseList);
+        assertTrue(expenseList.getLoan(0).isRepaid());
+    }
 }

--- a/src/test/java/seedu/duke/model/LoanTest.java
+++ b/src/test/java/seedu/duke/model/LoanTest.java
@@ -87,4 +87,97 @@ public class LoanTest {
         Loan loan = new Loan("  Bob  ", 15.00, null);
         assertEquals("Bob", loan.getBorrowerName());
     }
+
+    @Test
+    public void newLoan_amountRepaidIsZero() {
+        Loan loan = new Loan("John", 100.00, null);
+        assertEquals(0, loan.getAmountRepaid(), 0.0001);
+        assertEquals(100.00, loan.getOutstandingAmount(), 0.0001);
+    }
+
+    @Test
+    public void repay_partialAmount_updatesAmountRepaid() {
+        Loan loan = new Loan("John", 200.00, null);
+        loan.repay(50.00);
+        assertEquals(50.00, loan.getAmountRepaid(), 0.0001);
+        assertEquals(150.00, loan.getOutstandingAmount(), 0.0001);
+        assertFalse(loan.isRepaid());
+    }
+
+    @Test
+    public void repay_fullAmount_marksAsRepaid() {
+        Loan loan = new Loan("John", 200.00, null);
+        loan.repay(200.00);
+        assertTrue(loan.isRepaid());
+        assertEquals(200.00, loan.getAmountRepaid(), 0.0001);
+        assertEquals(0, loan.getOutstandingAmount(), 0.01);
+    }
+
+    @Test
+    public void repay_multiplePartial_accumulatesCorrectly() {
+        Loan loan = new Loan("John", 200.00, null);
+        loan.repay(50.00);
+        loan.repay(100.00);
+        assertEquals(150.00, loan.getAmountRepaid(), 0.0001);
+        assertEquals(50.00, loan.getOutstandingAmount(), 0.0001);
+        assertFalse(loan.isRepaid());
+    }
+
+    @Test
+    public void repay_multiplePartialCoveringFull_marksAsRepaid() {
+        Loan loan = new Loan("John", 200.00, null);
+        loan.repay(100.00);
+        loan.repay(100.00);
+        assertTrue(loan.isRepaid());
+    }
+
+    @Test
+    public void repay_zeroAmount_throwsIllegalArgumentException() {
+        Loan loan = new Loan("John", 200.00, null);
+        assertThrows(IllegalArgumentException.class, () -> loan.repay(0));
+    }
+
+    @Test
+    public void repay_negativeAmount_throwsIllegalArgumentException() {
+        Loan loan = new Loan("John", 200.00, null);
+        assertThrows(IllegalArgumentException.class, () -> loan.repay(-50.00));
+    }
+
+    @Test
+    public void repay_exceedsOutstanding_throwsIllegalArgumentException() {
+        Loan loan = new Loan("John", 200.00, null);
+        assertThrows(IllegalArgumentException.class, () -> loan.repay(300.00));
+    }
+
+    @Test
+    public void setAmountRepaid_setsValueDirectly() {
+        Loan loan = new Loan("John", 200.00, null);
+        loan.setAmountRepaid(75.00);
+        assertEquals(75.00, loan.getAmountRepaid(), 0.0001);
+        assertEquals(125.00, loan.getOutstandingAmount(), 0.0001);
+        assertFalse(loan.isRepaid());
+    }
+
+    @Test
+    public void setAmountRepaid_fullAmount_marksAsRepaid() {
+        Loan loan = new Loan("John", 200.00, null);
+        loan.setAmountRepaid(200.00);
+        assertTrue(loan.isRepaid());
+    }
+
+    @Test
+    public void markRepaid_setsAmountRepaidToFullAmount() {
+        Loan loan = new Loan("John", 200.00, null);
+        loan.markRepaid();
+        assertEquals(200.00, loan.getAmountRepaid(), 0.0001);
+    }
+
+    @Test
+    public void toString_partiallyRepaidLoan_containsRemaining() {
+        Loan loan = new Loan("John", 200.00, LocalDate.of(2026, 4, 1));
+        loan.repay(50.00);
+        String result = loan.toString();
+        assertTrue(result.contains("$150.00"));
+        assertTrue(result.contains("remaining"));
+    }
 }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -416,6 +416,26 @@ public class ParserTest {
     }
 
     @Test
+    public void parse_repayCommandWithValidAmount_returnsRepayCommand() {
+        assertTrue(Parser.parse("repay 1 100", ui) instanceof RepayCommand);
+    }
+
+    @Test
+    public void parse_repayCommandWithZeroAmount_returnsNull() {
+        assertNull(Parser.parse("repay 1 0", ui));
+    }
+
+    @Test
+    public void parse_repayCommandWithNegativeAmount_returnsNull() {
+        assertNull(Parser.parse("repay 1 -5", ui));
+    }
+
+    @Test
+    public void parse_repayCommandWithThreeTokens_returnsNull() {
+        assertNull(Parser.parse("repay 1 50 extra", ui));
+    }
+
+    @Test
     public void parse_findCommandWithCategory_returnsFindCommand() {
         Command command = Parser.parse("find /c Food", ui);
         assertTrue(command instanceof FindCommand);

--- a/src/test/java/seedu/duke/storage/StorageTest.java
+++ b/src/test/java/seedu/duke/storage/StorageTest.java
@@ -429,4 +429,57 @@ public class StorageTest {
 
         assertEquals(0, loadedList.getLoanCount());
     }
+
+    @Test
+    public void saveAndLoad_partiallyRepaidLoan_roundTripMaintainsData() {
+        Path dataFilePath = tempDir.resolve("partial-loan.txt");
+        Storage storage = new Storage(dataFilePath.toString(), new Ui());
+
+        ExpenseList originalList = new ExpenseList();
+        Loan loan = new Loan("John", 200.00, LocalDate.parse("2026-04-01"));
+        loan.repay(75.00);
+        originalList.addLoan(loan);
+        storage.save(originalList);
+
+        ExpenseList loadedList = new ExpenseList();
+        storage.load(loadedList);
+
+        assertEquals(1, loadedList.getLoanCount());
+        Loan loaded = loadedList.getLoan(0);
+        assertFalse(loaded.isRepaid());
+        assertEquals(75.00, loaded.getAmountRepaid(), 0.0001);
+        assertEquals(125.00, loaded.getOutstandingAmount(), 0.0001);
+    }
+
+    @Test
+    public void load_oldFormatLoanLine_loadsWithZeroAmountRepaid() throws IOException {
+        Path dataFilePath = tempDir.resolve("old-format-loan.txt");
+        Files.writeString(dataFilePath, "LOAN | 100.00 | 2026-04-01 | Alice | false\n");
+
+        Storage storage = new Storage(dataFilePath.toString(), new Ui());
+        ExpenseList loadedList = new ExpenseList();
+        storage.load(loadedList);
+
+        assertEquals(1, loadedList.getLoanCount());
+        Loan loaded = loadedList.getLoan(0);
+        assertFalse(loaded.isRepaid());
+        assertEquals(0, loaded.getAmountRepaid(), 0.0001);
+        assertEquals(100.00, loaded.getOutstandingAmount(), 0.0001);
+    }
+
+    @Test
+    public void load_newFormatLoanLine_loadsAmountRepaid() throws IOException {
+        Path dataFilePath = tempDir.resolve("new-format-loan.txt");
+        Files.writeString(dataFilePath, "LOAN | 200.00 | 2026-04-01 | Bob | false | 50.0\n");
+
+        Storage storage = new Storage(dataFilePath.toString(), new Ui());
+        ExpenseList loadedList = new ExpenseList();
+        storage.load(loadedList);
+
+        assertEquals(1, loadedList.getLoanCount());
+        Loan loaded = loadedList.getLoan(0);
+        assertFalse(loaded.isRepaid());
+        assertEquals(50.00, loaded.getAmountRepaid(), 0.0001);
+        assertEquals(150.00, loaded.getOutstandingAmount(), 0.0001);
+    }
 }


### PR DESCRIPTION
This PR adds partial repayment for loans and fixes two incorrect error messages. (Fixes #137 #160  #161 

**Partial repayment (#161)**
Users can now record partial repayments via repay INDEX AMOUNT. The remaining balance is tracked and displayed. Omitting the amount still performs a full repayment for backward compatibility.

**Example flow:**
lend 200 bob
repay 1 100    → "Partial repayment of $100.00 recorded"
                 "[Outstanding: $100.00 remaining]"
repay 1 100    → "Great! Marked as repaid"

**Changes:**
Loan: added amountRepaid tracking with repay(), getOutstandingAmount(), setAmountRepaid()
RepayCommand: accepts optional amount, branches between full and partial repay
Parser: parseRepayCommand now allows repay INDEX [AMOUNT]
Storage: saves/loads amountRepaid as a 5th field; remains backward compatible with old 4-field save files
Ui: added showPartialRepay(), showRepayExceedsOutstanding(); updated help text and usage


**Bug fixes**

#137: lend 0 Bob now correctly says "Loan amounts must be greater than $0.00" instead of "Expense amounts"
#160: repay 0 now correctly says "Use 'loans' to see valid numbers" instead of "Use 'list'"

**Tests**
Added 24 new tests across LoanTest (+12), RepayCommandTest (+5), ParserTest (+4), and StorageTest (+3). All existing tests remain unchanged.