### PR TITLE
Fix find help to show optional keyword

### DIFF
--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -130,7 +130,7 @@ public class Ui {
         System.out.println("  delete INDEX                              - Delete an expense by index");
         System.out.println("  edit INDEX [/a AMOUNT] [/de DESC]         - Edit an existing expense");
         System.out.println("             [/c CATEGORY] [/da DATE]");
-        System.out.println("  find KEYWORD [/c CAT] [/dmin DATE]        - Find/filter expenses");
+        System.out.println("  find [KEYWORD] [/c CAT] [/dmin DATE]      - Find/filter expenses");
         System.out.println("       [/dmax DATE] [/amin AMT] [/amax AMT] [/sort asc|desc]");
         System.out.println("  sort category|date                        - Sort expenses");
         System.out.println("  stats                                     - Show spending statistics and graph " +
@@ -461,7 +461,7 @@ public class Ui {
      */
     public void showFindUsage() {
         System.out.println(LINE);
-        System.out.println("Usage: find KEYWORD [/c CATEGORY] [/dmin DATE]"
+        System.out.println("Usage: find [KEYWORD] [/c CATEGORY] [/dmin DATE]"
                 + " [/dmax DATE] [/amin AMT] [/amax AMT] [/sort asc|desc]");
         System.out.println("  find lunch                    - search by keyword");
         System.out.println("  find /c Food                  - list all in category");

--- a/src/test/java/seedu/duke/ui/UiTest.java
+++ b/src/test/java/seedu/duke/ui/UiTest.java
@@ -141,7 +141,7 @@ public class UiTest {
         assertTrue(output.contains("list [YYYY-MM]"));
         assertTrue(output.contains("budget [AMOUNT]"));
         assertTrue(output.contains("budget [YYYY-MM] [AMOUNT]"));
-        assertTrue(output.contains("find KEYWORD [/c CAT]"));
+        assertTrue(output.contains("find [KEYWORD] [/c CAT]"));
         assertTrue(output.contains("sort category|date"));
         assertTrue(output.contains("loans /all"));
         assertTrue(output.contains("repay INDEX"));
@@ -303,7 +303,7 @@ public class UiTest {
         results.add(expense);
 
         String usageOutput = captureOutput(ui::showFindUsage);
-        assertTrue(usageOutput.contains("Usage: find KEYWORD [/c CATEGORY] [/dmin DATE]"));
+        assertTrue(usageOutput.contains("Usage: find [KEYWORD] [/c CATEGORY] [/dmin DATE]"));
         assertTrue(usageOutput.contains("find lunch"));
         assertTrue(usageOutput.contains("find /c Food"));
         assertTrue(usageOutput.contains("/sort asc|desc"));


### PR DESCRIPTION
## Summary
- Fix inconsistency between UG and help text for `find` command
- `showHelp()` and `showFindUsage()` now show `[KEYWORD]` (optional) matching UG

Fixes #156