### PR TITLE
Validate find ranges and fix display

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -721,6 +721,16 @@ public class Parser {
             workingStr = (before + " " + remaining).trim();
         }
 
+        if (amountMin != null && amountMax != null && amountMin > amountMax) {
+            ui.showInvalidAmountRange();
+            return null;
+        }
+
+        if (dateMin != null && dateMax != null && dateMin.isAfter(dateMax)) {
+            ui.showInvalidDateRange();
+            return null;
+        }
+
         String keyword = workingStr.trim();
         boolean hasAnyFilter = categoryFilter != null || dateMin != null
                 || dateMax != null || amountMin != null || amountMax != null

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -249,6 +249,24 @@ public class Ui {
     }
 
     /**
+     * Displays an error when the minimum amount exceeds the maximum amount.
+     */
+    public void showInvalidAmountRange() {
+        System.out.println(LINE);
+        System.out.println("Minimum amount cannot be greater than maximum amount.");
+        System.out.println(LINE);
+    }
+
+    /**
+     * Displays an error when the start date is after the end date.
+     */
+    public void showInvalidDateRange() {
+        System.out.println(LINE);
+        System.out.println("Start date cannot be after end date.");
+        System.out.println(LINE);
+    }
+
+    /**
      * Displays an error when the user attempts to add a $0.00 expense.
      */
     public void showZeroAmountWarning() {
@@ -508,7 +526,10 @@ public class Ui {
         if (categoryFilter != null) {
             return "category [" + categoryFilter + "]";
         }
-        return "\"" + keyword + "\"";
+        if (!keyword.isEmpty()) {
+            return "\"" + keyword + "\"";
+        }
+        return "applied filters";
     }
 
     /**

--- a/src/test/java/seedu/duke/command/FindCommandTest.java
+++ b/src/test/java/seedu/duke/command/FindCommandTest.java
@@ -262,6 +262,16 @@ public class FindCommandTest {
         assertFalse(output.contains("Coffee"), "Matches keyword but before dmin");
     }
 
+    @Test
+    public void execute_filtersOnly_outputShowsAppliedFilters() {
+        ExpenseList expenseList = buildList();
+        FindCommand cmd = new FindCommand(new Ui(), "", null,
+                null, null, 5.00, null, null);
+        String output = captureOutput(() -> cmd.execute(expenseList));
+        assertTrue(output.contains("applied filters"));
+        assertFalse(output.contains("\"\""));
+    }
+
     // ===== Helper =====
 
     private String captureOutput(Runnable action) {

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -584,4 +584,24 @@ public class ParserTest {
     public void parse_lendCommandDateBeforeBorrower_returnsLendCommand() {
         assertTrue(Parser.parse("lend 20.00 /da 2026-04-01 John", ui) instanceof LendCommand);
     }
+
+    @Test
+    public void parse_findAminGreaterThanAmax_returnsNull() {
+        assertNull(Parser.parse("find /amin 100 /amax 50", ui));
+    }
+
+    @Test
+    public void parse_findAminEqualsAmax_returnsFindCommand() {
+        assertNotNull(Parser.parse("find /amin 50 /amax 50", ui));
+    }
+
+    @Test
+    public void parse_findDminAfterDmax_returnsNull() {
+        assertNull(Parser.parse("find /dmin 2026-06-01 /dmax 2026-01-01", ui));
+    }
+
+    @Test
+    public void parse_findDminEqualsDmax_returnsFindCommand() {
+        assertNotNull(Parser.parse("find /dmin 2026-03-01 /dmax 2026-03-01", ui));
+    }
 }


### PR DESCRIPTION
## Summary
- Validate `/amin` <= `/amax` and `/dmin` <= `/dmax` in `parseFindCommand()`, rejecting reversed ranges with clear error messages
- Fix `buildSearchDescription()` to show "applied filters" instead of empty `""` when using filter-only searches like `find /amin 5 /amax 20`
- Add `showInvalidAmountRange()` and `showInvalidDateRange()` to Ui following existing zero-param error method pattern

Fixes #125, Fixes #126, Fixes #157, Fixes #159