### PR TITLE
Add per-command help usage display

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -70,11 +70,10 @@ public class Parser {
             return parseListCommand(arguments, ui);
 
         case "help":
-            if (!arguments.isEmpty()) {
-                ui.showUnknownCommand();
-                return null;
+            if (arguments.isEmpty()) {
+                return new HelpCommand(ui);
             }
-            return new HelpCommand(ui);
+            return parseHelpCommand(arguments, ui);
 
         case "exit":
             if (!arguments.trim().isEmpty()) {
@@ -813,9 +812,51 @@ public class Parser {
     }
 
     /**
+     * Shows usage help for a specific command by routing to the matching Ui method.
+     *
+     * @param arguments The command name to show help for.
+     * @param ui        The Ui instance used to display the usage message.
+     * @return null always, since this only displays information.
+     */
+    private static Command parseHelpCommand(String arguments, Ui ui) {
+        switch (arguments.toLowerCase()) {
+        case "add":
+            ui.showAddUsage();
+            break;
+        case "delete":
+            ui.showDeleteUsage();
+            break;
+        case "edit":
+            ui.showEditUsage();
+            break;
+        case "find":
+            ui.showFindUsage();
+            break;
+        case "budget":
+            ui.showBudgetUsage();
+            break;
+        case "sort":
+            ui.showSortUsage();
+            break;
+        case "lend":
+            ui.showLendUsage();
+            break;
+        case "loans":
+            ui.showLoansUsage();
+            break;
+        case "repay":
+            ui.showRepayUsage();
+            break;
+        default:
+            ui.showUnknownCommand();
+            break;
+        }
+        return null;
+    }
+
+    /**
      * Parses a date string strictly following the YYYY-MM-DD format.
      * Impossible calendar dates are also rejected.
-     * Calls showInvalidDateFormat and returns null on failure.
      *
      * @param dateStr The raw date token to parse.
      * @param ui      The Ui instance used to display the error message on failure.

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -139,7 +139,7 @@ public class Ui {
         System.out.println("  loans                                     - Show outstanding loans");
         System.out.println("  loans /all                                - Show all loans (incl. repaid)");
         System.out.println("  repay INDEX [AMOUNT]                      - Repay a loan (fully or partially)");
-        System.out.println("  help                                      - Show this help menu");
+        System.out.println("  help [COMMAND]                             - Show help for a command");
         System.out.println("  exit                                      - Exit the application");
         System.out.println("  forecast                                  - Show end-of-month spending forecast");
         System.out.println("Note: DATE must be in YYYY-MM-DD format (e.g. 2026-03-24).");

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -584,4 +584,19 @@ public class ParserTest {
     public void parse_lendCommandDateBeforeBorrower_returnsLendCommand() {
         assertTrue(Parser.parse("lend 20.00 /da 2026-04-01 John", ui) instanceof LendCommand);
     }
+
+    @Test
+    public void parse_helpAdd_returnsNull() {
+        assertNull(Parser.parse("help add", ui));
+    }
+
+    @Test
+    public void parse_helpUnknownCommand_returnsNull() {
+        assertNull(Parser.parse("help xyz", ui));
+    }
+
+    @Test
+    public void parse_helpNoArgs_returnsHelpCommand() {
+        assertTrue(Parser.parse("help", ui) instanceof HelpCommand);
+    }
 }


### PR DESCRIPTION
## Summary
- `help add`, `help delete`, `help edit`, etc. now show command-specific usage
- Reuses existing `showXxxUsage()` methods in Ui — no new display logic
- `help` with no args still shows full help menu
- Unknown commands (`help xyz`) show "Unknown command" message

Fixes #122