### PR TITLE
Harden find and edit input validation

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -323,9 +323,12 @@ The user types `find` followed by an optional keyword and any combination of the
 All filters are composable: `find lunch /c Food /amin 5 /sort asc` finds expenses containing "lunch" in the Food category costing at least $5, sorted cheapest-first.
 
 **Implementation:**
-`Parser.parseFindCommand()` strips each recognised flag from the input string one at a time, using the same `indexOf()`-based algorithm as `parseAddCommand()`. The remaining text after all flags have been extracted becomes the keyword. If neither a keyword nor any filter flag is present, usage help is shown and `null` is returned.
+`Parser.parseFindCommand()` first checks for duplicate flags using the `indexOf()` vs `lastIndexOf()` pattern (same as `parseAddCommand()`). It then strips each recognised flag one at a time. The remaining text becomes the keyword. If neither a keyword nor any filter flag is present, usage help is shown and `null` is returned.
 
-After all flags are extracted, `parseFindCommand()` validates that any amount range (`/amin` <= `/amax`) and date range (`/dmin` <= `/dmax`) are logically consistent. Reversed ranges are rejected with `showInvalidAmountRange()` or `showInvalidDateRange()` and `null` is returned.
+After all flags are extracted, `parseFindCommand()` validates:
+- Negative `/amin` and `/amax` values are rejected (expenses cannot have negative amounts).
+- Amount range is logically consistent (`/amin` <= `/amax`). Reversed ranges are rejected with `showInvalidAmountRange()`.
+- Date range is logically consistent (`/dmin` <= `/dmax`). Reversed ranges are rejected with `showInvalidDateRange()`.
 
 A `FindCommand` is constructed with all seven parameters (keyword, category, dateMin, dateMax, amountMin, amountMax, sortOrder). During execution, each expense is tested against four private predicate methods — `matchesCategory()`, `matchesKeyword()`, `matchesDateRange()`, and `matchesAmountRange()` — each of which returns `true` when its corresponding filter is `null` (i.e., not set). This design means all filters are independently optional and composable without any conditional branching in the main loop.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -207,16 +207,17 @@ Sets, updates, or views a monthly spending budget.
 
 
 ### Finding and filtering expenses: `find`
-Searches your expense list using a keyword and/or filters. All filters are optional and can be combined freely.
+Searches your expense list using a keyword and/or filters. At least one keyword or filter must be provided.
 
-**Format:** `find [KEYWORD] [/c CATEGORY] [/dmin DATE] [/dmax DATE] [/amin AMOUNT] [/amax AMOUNT] [/sort asc|desc]`
+**Format:** `find KEYWORD [/c CATEGORY] [/dmin DATE] [/dmax DATE] [/amin AMOUNT] [/amax AMOUNT] [/sort asc|desc]`
 
-* `KEYWORD` searches across both description and category (case-insensitive).
+* `KEYWORD` searches across both description and category (case-insensitive). It can be omitted if at least one filter flag is provided.
 * `/c CATEGORY` filters by exact category match.
 * `/dmin` and `/dmax` filter by date range (inclusive, YYYY-MM-DD format).
-* `/amin` and `/amax` filter by amount range (inclusive). Minimum must not exceed maximum.
+* `/amin` and `/amax` filter by amount range (inclusive). Values must be non-negative. Minimum must not exceed maximum.
 * `/dmin` must not be after `/dmax`. Reversed ranges are rejected with an error message.
 * `/sort asc` or `/sort desc` sorts results by amount.
+* Each filter flag can only be used once per command.
 
 **Examples:**
 * `find coffee` *(All expenses containing "coffee")*

--- a/docs/team/trijalsrimal.md
+++ b/docs/team/trijalsrimal.md
@@ -27,6 +27,9 @@ This section summarizes my specific contributions to the project. My primary foc
     * Fixed help text inconsistency where `find KEYWORD` was shown as required instead of optional (#156)
     * Added per-command help (`help add`, `help find`, etc.) reusing existing Ui usage methods (#122)
     * Split Storage UML diagram into separate load and save diagrams for PDF readability (#170, #171, #172)
+    * Added pipe character validation to edit command to prevent save file corruption
+    * Added negative amount rejection for find `/amin` and `/amax` filters
+    * Added duplicate flag detection for all find filter flags (`/sort`, `/amin`, `/amax`, `/dmin`, `/dmax`)
 
 * **Contributions to the UG**:
     * Authored the `find`, `delete`, `budget`, `stats`, and `help` command sections.

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -369,6 +369,10 @@ public class Parser {
         }
 
         String flagSection = (indexSplit.length > 1) ? indexSplit[1].trim() : "";
+        if (flagSection.contains("|")) {
+            ui.showInvalidCharacterWarning();
+            return null;
+        }
         if (flagSection.isEmpty()) {
             ui.showEditUsage();
             return null;
@@ -633,6 +637,27 @@ public class Parser {
         Double amountMax = null;
         String sortOrder = null;
 
+        if (workingStr.indexOf("/sort") != workingStr.lastIndexOf("/sort")) {
+            ui.showDuplicateFlagWarning("/sort");
+            return null;
+        }
+        if (workingStr.indexOf("/amin") != workingStr.lastIndexOf("/amin")) {
+            ui.showDuplicateFlagWarning("/amin");
+            return null;
+        }
+        if (workingStr.indexOf("/amax") != workingStr.lastIndexOf("/amax")) {
+            ui.showDuplicateFlagWarning("/amax");
+            return null;
+        }
+        if (workingStr.indexOf("/dmin") != workingStr.lastIndexOf("/dmin")) {
+            ui.showDuplicateFlagWarning("/dmin");
+            return null;
+        }
+        if (workingStr.indexOf("/dmax") != workingStr.lastIndexOf("/dmax")) {
+            ui.showDuplicateFlagWarning("/dmax");
+            return null;
+        }
+
         if (workingStr.contains("/sort")) {
             int flagIdx = workingStr.indexOf("/sort");
             String after = workingStr.substring(flagIdx + "/sort".length()).trim();
@@ -654,6 +679,10 @@ public class Parser {
             String[] tokens = after.split("\\s+", 2);
             try {
                 amountMin = Double.parseDouble(tokens[0]);
+                if (amountMin < 0) {
+                    ui.showInvalidAmount();
+                    return null;
+                }
             } catch (NumberFormatException e) {
                 ui.showInvalidAmount();
                 return null;
@@ -669,6 +698,10 @@ public class Parser {
             String[] tokens = after.split("\\s+", 2);
             try {
                 amountMax = Double.parseDouble(tokens[0]);
+                if (amountMax < 0) {
+                    ui.showInvalidAmount();
+                    return null;
+                }
             } catch (NumberFormatException e) {
                 ui.showInvalidAmount();
                 return null;

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -619,4 +619,34 @@ public class ParserTest {
     public void parse_helpNoArgs_returnsHelpCommand() {
         assertTrue(Parser.parse("help", ui) instanceof HelpCommand);
     }
+
+    @Test
+    public void parse_editWithPipeChar_returnsNull() {
+        assertNull(Parser.parse("edit 1 /de Coffee | Latte", ui));
+    }
+
+    @Test
+    public void parse_findNegativeAmin_returnsNull() {
+        assertNull(Parser.parse("find /amin -5", ui));
+    }
+
+    @Test
+    public void parse_findNegativeAmax_returnsNull() {
+        assertNull(Parser.parse("find /amax -1", ui));
+    }
+
+    @Test
+    public void parse_findDuplicateSort_returnsNull() {
+        assertNull(Parser.parse("find /sort asc /sort desc", ui));
+    }
+
+    @Test
+    public void parse_findDuplicateAmin_returnsNull() {
+        assertNull(Parser.parse("find /amin 5 /amin 10", ui));
+    }
+
+    @Test
+    public void parse_findDuplicateDmin_returnsNull() {
+        assertNull(Parser.parse("find /dmin 2026-01-01 /dmin 2026-02-01", ui));
+    }
 }

--- a/src/test/java/seedu/duke/ui/UiTest.java
+++ b/src/test/java/seedu/duke/ui/UiTest.java
@@ -292,7 +292,7 @@ public class UiTest {
         assertTrue(budgetUsageOutput.contains("budget <YYYY-MM> <amount>"));
 
         assertTrue(captureOutput(ui::showInvalidBudget)
-                .contains("Budget must be a number greater then 0."));
+                .contains("Budget must be a number greater than 0."));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- **Edit pipe injection fix**: `parseEditCommand()` now rejects `|` in `/de` and `/c` values, preventing save file corruption (same validation that `parseAddCommand` already has)
- **Find negative amount rejection**: `/amin` and `/amax` now reject negative values
- **Find duplicate flag detection**: `/sort`, `/amin`, `/amax`, `/dmin`, `/dmax` now use `indexOf` vs `lastIndexOf` duplicate detection (same pattern as `/c` and `/da` in `parseAddCommand`)
- **UG**: Clarified that `find` requires at least one keyword or filter flag, added notes about non-negative amounts and single-use flags
- **DG**: Updated Find section with duplicate detection and negative amount validation details
- **PPP**: Updated with final fixes

All changes follow existing codebase patterns exactly. No new methods added to Ui — reuses `showInvalidAmount()`, `showInvalidCharacterWarning()`, and `showDuplicateFlagWarning()`.