### PR TITLE
Fix lend pipe injection and help text

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -418,7 +418,7 @@ During `save()`, the `Storage` class:
 
 ### Input Validation (Strict Commands)
 
-The `total` and `forecast` commands do not accept any arguments.
+The `total`, `forecast`, and `clear` commands do not accept any arguments.
 If trailing text is detected after these keywords, the parser shows an unknown command message and returns `null`.
 
 The `help` command accepts either no arguments or a single command name.

--- a/docs/team/trijalsrimal.md
+++ b/docs/team/trijalsrimal.md
@@ -30,6 +30,8 @@ This section summarizes my specific contributions to the project. My primary foc
     * Added pipe character validation to edit command to prevent save file corruption
     * Added negative amount rejection for find `/amin` and `/amax` filters
     * Added duplicate flag detection for all find filter flags (`/sort`, `/amin`, `/amax`, `/dmin`, `/dmax`)
+    * Added pipe character validation to lend command to prevent borrower name corruption
+    * Fixed help menu: added `clear`, updated `delete` to show batch modes, updated `stats` description
 
 * **Contributions to the UG**:
     * Authored the `find`, `delete`, `budget`, `stats`, and `help` command sections.

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -480,6 +480,10 @@ public class Parser {
             ui.showLendUsage();
             return null;
         }
+        if (arguments.contains("|")) {
+            ui.showInvalidCharacterWarning();
+            return null;
+        }
 
         String[] inputParts = arguments.split("\\s+", 2);
         if (inputParts.length < 2) {

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -127,14 +127,13 @@ public class Ui {
         System.out.println("  total                                     - Show total amount spent");
         System.out.println("  budget [AMOUNT]                           - View/set current month's budget");
         System.out.println("  budget [YYYY-MM] [AMOUNT]                 - View/set a specific month's budget");
-        System.out.println("  delete INDEX                              - Delete an expense by index");
+        System.out.println("  delete INDEX|/c CAT|/da DATE              - Delete expense(s)");
         System.out.println("  edit INDEX [/a AMOUNT] [/de DESC]         - Edit an existing expense");
         System.out.println("             [/c CATEGORY] [/da DATE]");
         System.out.println("  find [KEYWORD] [/c CAT] [/dmin DATE]      - Find/filter expenses");
         System.out.println("       [/dmax DATE] [/amin AMT] [/amax AMT] [/sort asc|desc]");
         System.out.println("  sort category|date|amount                 - Sort expenses");
-        System.out.println("  stats                                     - Show spending statistics and graph " +
-                "by category");
+        System.out.println("  stats [YYYY]                              - Show yearly budget dashboard");
         System.out.println("  lend AMOUNT BORROWER [/da DATE]           - Record money lent to someone");
         System.out.println("  loans                                     - Show outstanding loans");
         System.out.println("  loans /all                                - Show all loans (incl. repaid)");

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -649,4 +649,9 @@ public class ParserTest {
     public void parse_findDuplicateDmin_returnsNull() {
         assertNull(Parser.parse("find /dmin 2026-01-01 /dmin 2026-02-01", ui));
     }
+
+    @Test
+    public void parse_lendWithPipeChar_returnsNull() {
+        assertNull(Parser.parse("lend 50 Alice | Bob", ui));
+    }
 }


### PR DESCRIPTION
## Summary
- **A19 fix**: Added pipe `|` validation to `parseLendCommand()` — prevents borrower name with `|` from corrupting save file and causing data loss on reload (same guard as `parseAddCommand` and `parseEditCommand`)
- **A22 fix**: Updated help menu `delete` line to show all three forms: `INDEX|/c CAT|/da DATE`
- **A23 fix**: Updated help menu `stats` to show `stats [YYYY]` with accurate description
- **A24 fix**: Added `clear` to DG "Input Validation (Strict Commands)" section
- **PPP**: Updated with final fixes
- Test added for lend pipe validation